### PR TITLE
handle illegal escape chars in format strings regardless of OS.

### DIFF
--- a/src/it/illegal-escape-char/pom.xml
+++ b/src/it/illegal-escape-char/pom.xml
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+
+	<groupId>com.github.timm-permeance.it</groupId>
+	<artifactId>simple-it</artifactId>
+	<version>1.0-SNAPSHOT</version>
+
+	<description>A simple IT verifying the basic use case.</description>
+
+	<properties>
+		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+		<cucumber.version>1.1.8</cucumber.version>
+	</properties>
+
+	<dependencies>
+		<dependency>
+			<groupId>info.cukes</groupId>
+			<artifactId>cucumber-junit</artifactId>
+			<version>${cucumber.version}</version>
+		</dependency>
+		<dependency>
+			<groupId>info.cukes</groupId>
+			<artifactId>cucumber-java</artifactId>
+			<version>${cucumber.version}</version>
+		</dependency>
+	</dependencies>
+
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>@project.groupId@</groupId>
+				<artifactId>@project.artifactId@</artifactId>
+				<version>@project.version@</version>
+				<executions>
+					<execution>
+						<id>generateRunners</id>
+						<phase>validate</phase>
+						<goals>
+							<goal>generateRunners</goal>
+						</goals>
+						<configuration>
+							<glue>foo, bar</glue>
+							<cucumberOutputDir>target\cucumber-reports</cucumberOutputDir>
+						</configuration>
+					</execution>
+				</executions>
+			</plugin>
+		</plugins>
+	</build>
+</project>

--- a/src/it/illegal-escape-char/src/test/resources/features/feature1.feature
+++ b/src/it/illegal-escape-char/src/test/resources/features/feature1.feature
@@ -1,0 +1,14 @@
+Feature: Feature1
+
+  Scenario: Generate Junit Runner for each feature file
+    Given I have feature files
+    When I generate Maven sources
+    Then the file "target/generated-test-sources/1IT.java" should exist
+    And it should contain:
+    """
+    @RunWith(Cucumber.class)
+    @CucumberOptions(strict = true, features = {"classpath:features/feature1.feature"}, format = {"json:target/cucumber-parallel/1.json",
+    "pretty"}, monochrome = false, tags = {"@complete", "@accepted"}, glue = { "foo", "bar" })
+    public class Parallel01IT {
+    }
+    """

--- a/src/it/illegal-escape-char/src/test/resources/features/feature1.feature
+++ b/src/it/illegal-escape-char/src/test/resources/features/feature1.feature
@@ -7,7 +7,7 @@ Feature: Feature1
     And it should contain:
     """
     @RunWith(Cucumber.class)
-    @CucumberOptions(strict = true, features = {"classpath:features/feature1.feature"}, format = {"json:target/cucumber-parallel/1.json",
+    @CucumberOptions(strict = true, features = {"classpath:features/feature1.feature"}, format = {"json:target/cucumber-reports/1.json",
     "pretty"}, monochrome = false, tags = {"@complete", "@accepted"}, glue = { "foo", "bar" })
     public class Parallel01IT {
     }

--- a/src/it/illegal-escape-char/verify.groovy
+++ b/src/it/illegal-escape-char/verify.groovy
@@ -1,0 +1,20 @@
+import org.junit.Assert;
+import static org.hamcrest.Matchers.equalToIgnoringWhiteSpace;
+
+File suite01 = new File( basedir, "target/generated-test-sources/cucumber/Parallel01IT.java" );
+
+assert suite01.isFile()
+
+String expected01=
+"""import org.junit.runner.RunWith;
+
+import cucumber.api.CucumberOptions;
+import cucumber.api.junit.Cucumber;
+
+@RunWith(Cucumber.class)
+@CucumberOptions(strict = true, features = {"classpath:features/feature1.feature"}, format = {"json:target/cucumber-reports/1.json",
+"pretty"}, monochrome = false, tags = {"@complete", "@accepted"}, glue = { "foo", "bar" })
+public class Parallel01IT {
+}"""
+
+Assert.assertThat(suite01.text, equalToIgnoringWhiteSpace(expected01))

--- a/src/main/java/com/github/timm/cucumber/generate/CucumberITGenerator.java
+++ b/src/main/java/com/github/timm/cucumber/generate/CucumberITGenerator.java
@@ -174,7 +174,8 @@ public class CucumberITGenerator {
         for (int i = 0; i < formatStrs.length; i++) {
             final String formatStr = formatStrs[i].trim();
             sb.append(String.format("\"%s:%s/%s.%s\"", formatStr,
-                    config.getCucumberOutputDir(), fileCounter, formatStr));
+                    config.getCucumberOutputDir()
+                    .replace('\\', '/'), fileCounter, formatStr));
 
             if (i < formatStrs.length - 1) {
                 sb.append(", ");


### PR DESCRIPTION
Rather than solely replacing the File.separatorChar that is dependent on OS, the plugin should handle invalid escape chars specified directly in the cucumberOutputDir. For example, someone could theoretically specify a full path such as C:\blah\somedir\target\etc in the pom file.

Fixes issue #10 