### PR TITLE
Updated to work with Cucumber version 1.0.4

### DIFF
--- a/src/main/resources/cucumber-junit-runner.vm
+++ b/src/main/resources/cucumber-junit-runner.vm
@@ -1,11 +1,10 @@
 import org.junit.runner.RunWith;
 
-import cucumber.api.CucumberOptions;
-import cucumber.api.junit.Cucumber;
+import cucumber.junit.Cucumber;
 
 @RunWith(Cucumber.class)
-@CucumberOptions(strict = $strict,
-    features = {"classpath:$featureFile"},
+@Cucumber.Options(strict = $strict,
+    features = {"$featureFile"},
     format = {$reports, "pretty"},
     monochrome = ${monochrome},
     tags = {$tags},


### PR DESCRIPTION
Some classes/packages have been restructured and it looks like you don't need to prepend classpath: to the feature file path.