### PR TITLE
Added support for TestNG

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
 
 	<groupId>com.github.temyers</groupId>
 	<artifactId>cucumber-jvm-parallel-plugin</artifactId>
-	<version>1.0.2-SNAPSHOT</version>
+	<version>1.1.0-SNAPSHOT</version>
 	<packaging>maven-plugin</packaging>
 
 	<name>cucumber-jvm-parallel-plugin Maven Plugin</name>

--- a/readme.md
+++ b/readme.md
@@ -1,11 +1,11 @@
 cucumber-jvm-parallel-plugin ![CI status](https://travis-ci.org/temyers/cucumber-jvm-parallel-plugin.svg?branch=master)
 ============================
 
-A common approach for running Cucumber features in parallel is to create a suite of Cucumber JUnit runners, one for each suite of tests you wish to run in parallel.  For maximum parallelism, there should be a runner per feature file.
+A common approach for running Cucumber features in parallel is to create a suite of Cucumber runners, one for each suite of tests you wish to run in parallel.  For maximum parallelism, there should be a runner per feature file.
 
 This is a pain to maintain and not very DRY.
 
-This is where the cucumber-jvm-parallel-plugin comes in.  This plugin automatically generates a Cucumber JUnit runner for each feature file found in your project.
+This is where the cucumber-jvm-parallel-plugin comes in.  This plugin automatically generates a Cucumber JUnit or TestNG runner for each feature file found in your project.
 
 Usage
 -----
@@ -16,7 +16,7 @@ Add the following to your POM file:
 <plugin>
   <groupId>com.github.temyers</groupId>
   <artifactId>cucumber-jvm-parallel-plugin</artifactId>
-  <version>1.0-SNAPSHOT</version>
+  <version>1.1.0-SNAPSHOT</version>
   <executions>
     <execution>
       <id>generateRunners</id>
@@ -29,7 +29,7 @@ Add the following to your POM file:
           <!-- comma separated list of package names to scan for glue code -->
          <glue>foo, bar</glue>
          <!-- These are the default values -->
-          <!-- Where to output the generated Junit tests -->
+          <!-- Where to output the generated tests -->
            <outputDirectory>${project.build.directory}/generated-test-sources/cucumber</outputDirectory>
            <!-- The diectory containing your feature files.  -->
           <featuresDirectory>src/test/resources/features/</featuresDirectory>
@@ -46,6 +46,8 @@ Add the following to your POM file:
          <!-- If set to true, only feature files containing the required tags shall be generated. -->
          <!-- Excluded tags (~@notMe) are ignored. -->
          <filterFeaturesByTags>false</filterFeaturesByTags>
+         <!-- Generate TestNG runners instead of JUnit ones. --> 
+         <useTestNG>false</useTestNG>
       </configuration>
     </execution>
   </executions>
@@ -56,11 +58,11 @@ If `cucumber.options` VM argument is specified as per the [Cucumber CLI options]
 
 Where glue is a comma separated list of package names to use for the Cucumber Glue.
 
-The plugin will search `featuresDirectory` for `*.feature` files and generate a JUnit test for each one.
+The plugin will search `featuresDirectory` for `*.feature` files and generate a JUnit test for each one. If you prefer to generate TestNG tests, set `useTestNG` to true
 
 The Java source is generated in `outputDirectory`, and will have the pattern `ParallelXXIT.java`, where `XX` is a one up counter.
 
-Each JUnit test is configured to output the results to a separate output file under `target/cucumber-parallel`
+Each runner is configured to output the results to a separate output file under `target/cucumber-parallel`
 
 FAQ
 ===
@@ -69,6 +71,10 @@ A. The plugin is considered feature complete.  If you feel there is something mi
 
 Changelog
 =========
+1.1.0
+-----
+* pr#13 - Added support for generating TestNG runners.
+
 1.0.1
 -----
 * issue#10 - compilation error on Windows.
@@ -80,9 +86,9 @@ Contributing
 
 To contribute:
 
-* Create an integration test to demonstrate the behaviour under `src/it/`.  For example, to add support for multiple output formats:
-    * Create src/it/multiple-format
-    * copy the contents of the src/it/simple-it directory and update the pom/src as appropriate to demonstrate the configuration.  Update the verify.groovy to implement the test for your feature.
+* Create an integration test to demonstrate the behaviour under `src/it/`.  For example, to add support for multiple output formats for junit runners:
+    * Create src/it/junit/multiple-format
+    * copy the contents of the src/it/junit/simple-it directory and update the pom/src as appropriate to demonstrate the configuration.  Update the verify.groovy to implement the test for your feature.
     * Run `mvn clean install -Prun-its` to run the integration tests.
 * Implement the feature
 * When all tests are passing, submit a pull request.

--- a/src/it/testng/filter-by-tag/pom.xml
+++ b/src/it/testng/filter-by-tag/pom.xml
@@ -1,0 +1,55 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+
+	<groupId>com.github.timm-permeance.it</groupId>
+	<artifactId>simple-it</artifactId>
+	<version>1.0-SNAPSHOT</version>
+
+	<description>A simple IT verifying the basic use case.</description>
+
+	<properties>
+		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+		<cucumber.version>1.1.8</cucumber.version>
+	</properties>
+
+	<dependencies>
+		<dependency>
+			<groupId>info.cukes</groupId>
+			<artifactId>cucumber-testng</artifactId>
+			<version>${cucumber.version}</version>
+		</dependency>
+		<dependency>
+			<groupId>info.cukes</groupId>
+			<artifactId>cucumber-java</artifactId>
+			<version>${cucumber.version}</version>
+		</dependency>
+	</dependencies>
+
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>@project.groupId@</groupId>
+				<artifactId>@project.artifactId@</artifactId>
+				<version>@project.version@</version>
+				<executions>
+					<execution>
+						<id>generateRunners</id>
+						<phase>validate</phase>
+						<goals>
+							<goal>generateRunners</goal>
+						</goals>
+						<configuration>
+							<glue>foo, bar</glue>
+							<!-- Only 1 feature contains this tag -->
+							<tags>"@feature1"</tags>
+							<filterFeaturesByTags>true</filterFeaturesByTags>
+							<useTestNG>true</useTestNG>
+						</configuration>
+					</execution>
+				</executions>
+			</plugin>
+		</plugins>
+	</build>
+</project>

--- a/src/it/testng/filter-by-tag/src/test/resources/features/feature1.feature
+++ b/src/it/testng/filter-by-tag/src/test/resources/features/feature1.feature
@@ -1,0 +1,5 @@
+@feature1
+Feature: Feature1
+
+  Scenario: Matching tags are included
+    	Then this feature should should be included

--- a/src/it/testng/filter-by-tag/src/test/resources/features/feature2.feature
+++ b/src/it/testng/filter-by-tag/src/test/resources/features/feature2.feature
@@ -1,0 +1,5 @@
+@feature2
+Feature: Feature2
+
+  Scenario: Non Matching tags are excluded
+    	Then this feature should should be excluded

--- a/src/it/testng/filter-by-tag/verify.groovy
+++ b/src/it/testng/filter-by-tag/verify.groovy
@@ -1,0 +1,21 @@
+import org.junit.Assert;
+import static org.hamcrest.Matchers.equalToIgnoringWhiteSpace;
+
+File suite01 = new File( basedir, "target/generated-test-sources/cucumber/Parallel01IT.java" );
+File suite02 = new File( basedir, "target/generated-test-sources/cucumber/Parallel02IT.java" );
+
+assert suite01.isFile()
+// Only one file should be created
+assert !suite02.isFile()
+
+String expected01=
+"""import cucumber.api.CucumberOptions;
+import cucumber.api.testng.AbstractTestNGCucumberTests;
+
+@CucumberOptions(strict = true, features = {"classpath:features/feature1.feature"}, format = {"json:target/cucumber-parallel/1.json",
+"pretty"}, monochrome = false, tags = {"@feature1"}, glue = { "foo", "bar" })
+public class Parallel01IT extends AbstractTestNGCucumberTests {
+}"""
+
+Assert.assertThat(suite01.text, equalToIgnoringWhiteSpace(expected01))
+

--- a/src/it/testng/filter-by-tag5-keep-tags-if-no-tags-in-cucumber-opts/pom.xml
+++ b/src/it/testng/filter-by-tag5-keep-tags-if-no-tags-in-cucumber-opts/pom.xml
@@ -1,0 +1,56 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+
+	<groupId>com.github.timm-permeance.it</groupId>
+	<artifactId>simple-it</artifactId>
+	<version>1.0-SNAPSHOT</version>
+
+	<description>A simple IT verifying the basic use case.</description>
+
+	<properties>
+	    <cucumber.options>--format json</cucumber.options>
+		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+		<cucumber.version>1.1.8</cucumber.version>
+	</properties>
+
+	<dependencies>
+		<dependency>
+			<groupId>info.cukes</groupId>
+			<artifactId>cucumber-testng</artifactId>
+			<version>${cucumber.version}</version>
+		</dependency>
+		<dependency>
+			<groupId>info.cukes</groupId>
+			<artifactId>cucumber-java</artifactId>
+			<version>${cucumber.version}</version>
+		</dependency>
+	</dependencies>
+
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>@project.groupId@</groupId>
+				<artifactId>@project.artifactId@</artifactId>
+				<version>@project.version@</version>
+				<executions>
+					<execution>
+						<id>generateRunners</id>
+						<phase>validate</phase>
+						<goals>
+							<goal>generateRunners</goal>
+						</goals>
+						<configuration>
+							<glue>foo, bar</glue>
+							<!-- Only 1 feature contains this tag -->
+							<tags>"@feature1"</tags>
+							<filterFeaturesByTags>true</filterFeaturesByTags>
+							<useTestNG>true</useTestNG>
+						</configuration>
+					</execution>
+				</executions>
+			</plugin>
+		</plugins>
+	</build>
+</project>

--- a/src/it/testng/filter-by-tag5-keep-tags-if-no-tags-in-cucumber-opts/src/test/resources/features/feature1.feature
+++ b/src/it/testng/filter-by-tag5-keep-tags-if-no-tags-in-cucumber-opts/src/test/resources/features/feature1.feature
@@ -1,0 +1,5 @@
+@feature1
+Feature: Feature1
+
+  Scenario: Matching tags are included
+    	Then this feature should should be included

--- a/src/it/testng/filter-by-tag5-keep-tags-if-no-tags-in-cucumber-opts/src/test/resources/features/feature2.feature
+++ b/src/it/testng/filter-by-tag5-keep-tags-if-no-tags-in-cucumber-opts/src/test/resources/features/feature2.feature
@@ -1,0 +1,5 @@
+@feature2
+Feature: Feature2
+
+  Scenario: Non-matching tags are excluded
+    	Then this feature should should be excluded

--- a/src/it/testng/filter-by-tag5-keep-tags-if-no-tags-in-cucumber-opts/verify.groovy
+++ b/src/it/testng/filter-by-tag5-keep-tags-if-no-tags-in-cucumber-opts/verify.groovy
@@ -1,0 +1,20 @@
+import org.junit.Assert;
+import static org.hamcrest.Matchers.equalToIgnoringWhiteSpace;
+
+File suite01 = new File( basedir, "target/generated-test-sources/cucumber/Parallel01IT.java" );
+File suite02 = new File( basedir, "target/generated-test-sources/cucumber/Parallel02IT.java" );
+
+assert suite01.isFile()
+// Only one file should be created
+assert !suite02.isFile()
+
+String expected01=
+"""import cucumber.api.CucumberOptions;
+import cucumber.api.testng.AbstractTestNGCucumberTests;
+
+@CucumberOptions(strict = true, features = {"classpath:features/feature1.feature"}, format = {"json:target/cucumber-parallel/1.json",
+"pretty"}, monochrome = false, tags = {"@feature1"}, glue = { "foo", "bar" })
+public class Parallel01IT extends AbstractTestNGCucumberTests {
+}"""
+
+Assert.assertThat(suite01.text, equalToIgnoringWhiteSpace(expected01))

--- a/src/it/testng/filter-by-tag6-override-tags-if-tags-in-cucumber-opts/pom.xml
+++ b/src/it/testng/filter-by-tag6-override-tags-if-tags-in-cucumber-opts/pom.xml
@@ -1,0 +1,56 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+
+	<groupId>com.github.timm-permeance.it</groupId>
+	<artifactId>simple-it</artifactId>
+	<version>1.0-SNAPSHOT</version>
+
+	<description>A simple IT verifying the basic use case.</description>
+
+	<properties>
+	    <cucumber.options>--tags @override</cucumber.options>
+		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+		<cucumber.version>1.1.8</cucumber.version>
+	</properties>
+
+	<dependencies>
+		<dependency>
+			<groupId>info.cukes</groupId>
+			<artifactId>cucumber-testng</artifactId>
+			<version>${cucumber.version}</version>
+		</dependency>
+		<dependency>
+			<groupId>info.cukes</groupId>
+			<artifactId>cucumber-java</artifactId>
+			<version>${cucumber.version}</version>
+		</dependency>
+	</dependencies>
+
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>@project.groupId@</groupId>
+				<artifactId>@project.artifactId@</artifactId>
+				<version>@project.version@</version>
+				<executions>
+					<execution>
+						<id>generateRunners</id>
+						<phase>validate</phase>
+						<goals>
+							<goal>generateRunners</goal>
+						</goals>
+						<configuration>
+							<glue>foo, bar</glue>
+							<!-- Only 1 feature contains this tag -->
+							<tags>"@feature1"</tags>
+							<filterFeaturesByTags>true</filterFeaturesByTags>
+							<useTestNG>true</useTestNG>
+						</configuration>
+					</execution>
+				</executions>
+			</plugin>
+		</plugins>
+	</build>
+</project>

--- a/src/it/testng/filter-by-tag6-override-tags-if-tags-in-cucumber-opts/src/test/resources/features/feature1.feature
+++ b/src/it/testng/filter-by-tag6-override-tags-if-tags-in-cucumber-opts/src/test/resources/features/feature1.feature
@@ -1,0 +1,5 @@
+@feature1 @override
+Feature: Feature1
+
+  Scenario: Matching override tags are included
+    	Then this feature should be included

--- a/src/it/testng/filter-by-tag6-override-tags-if-tags-in-cucumber-opts/src/test/resources/features/feature2.feature
+++ b/src/it/testng/filter-by-tag6-override-tags-if-tags-in-cucumber-opts/src/test/resources/features/feature2.feature
@@ -1,0 +1,5 @@
+@feature2 @override
+Feature: Feature2
+
+  Scenario: Matching override tags are included
+    	Then this feature should be included

--- a/src/it/testng/filter-by-tag6-override-tags-if-tags-in-cucumber-opts/src/test/resources/features/feature3.feature
+++ b/src/it/testng/filter-by-tag6-override-tags-if-tags-in-cucumber-opts/src/test/resources/features/feature3.feature
@@ -1,0 +1,5 @@
+@feature3
+Feature: Feature3
+
+  Scenario: Non-matching override tags are excluded
+    	Then this feature should be excluded

--- a/src/it/testng/filter-by-tag6-override-tags-if-tags-in-cucumber-opts/verify.groovy
+++ b/src/it/testng/filter-by-tag6-override-tags-if-tags-in-cucumber-opts/verify.groovy
@@ -1,0 +1,41 @@
+import org.junit.Assert;
+import static org.hamcrest.Matchers.equalToIgnoringWhiteSpace;
+
+File suite01 = new File( basedir, "target/generated-test-sources/cucumber/Parallel01IT.java" );
+File suite02 = new File( basedir, "target/generated-test-sources/cucumber/Parallel02IT.java" );
+File suite03 = new File( basedir, "target/generated-test-sources/cucumber/Parallel03IT.java" );
+
+assert suite01.isFile()
+assert suite02.isFile()
+// Only two files should be created
+assert !suite03.isFile()
+
+String expected01=
+"""import cucumber.api.CucumberOptions;
+import cucumber.api.testng.AbstractTestNGCucumberTests;
+
+@CucumberOptions(strict = true, features = {"classpath:features/feature1.feature"}, format = {"json:target/cucumber-parallel/1.json",
+"pretty"}, monochrome = false, tags = {"@override"}, glue = { "foo", "bar" })
+public class Parallel01IT extends AbstractTestNGCucumberTests {
+}"""
+
+Assert.assertThat(suite01.text, equalToIgnoringWhiteSpace(expected01))
+
+String expected02=
+"""import cucumber.api.CucumberOptions;
+import cucumber.api.testng.AbstractTestNGCucumberTests;
+
+@CucumberOptions(strict = true, features = {"classpath:features/feature2.feature"}, format = {"json:target/cucumber-parallel/2.json",
+"pretty"}, monochrome = false, tags = {"@override"}, glue = { "foo", "bar" })
+public class Parallel02IT extends AbstractTestNGCucumberTests {
+}"""
+
+// Depending on the OS, listFiles can list files in different order.  The actual order of files isn't necessary
+
+if(suite01.text.contains("feature1") ){
+	Assert.assertThat(suite01.text, equalToIgnoringWhiteSpace(expected01))
+	Assert.assertThat(suite02.text, equalToIgnoringWhiteSpace(expected02))
+}else{
+	Assert.assertThat(suite02.text, equalToIgnoringWhiteSpace(expected01))
+	Assert.assertThat(suite01.text, equalToIgnoringWhiteSpace(expected02))
+}

--- a/src/it/testng/illegal-escape-char/pom.xml
+++ b/src/it/testng/illegal-escape-char/pom.xml
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+
+	<groupId>com.github.timm-permeance.it</groupId>
+	<artifactId>simple-it</artifactId>
+	<version>1.0-SNAPSHOT</version>
+
+	<description>A simple IT verifying the basic use case.</description>
+
+	<properties>
+		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+		<cucumber.version>1.1.8</cucumber.version>
+	</properties>
+
+	<dependencies>
+		<dependency>
+			<groupId>info.cukes</groupId>
+			<artifactId>cucumber-testng</artifactId>
+			<version>${cucumber.version}</version>
+		</dependency>
+		<dependency>
+			<groupId>info.cukes</groupId>
+			<artifactId>cucumber-java</artifactId>
+			<version>${cucumber.version}</version>
+		</dependency>
+	</dependencies>
+
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>@project.groupId@</groupId>
+				<artifactId>@project.artifactId@</artifactId>
+				<version>@project.version@</version>
+				<executions>
+					<execution>
+						<id>generateRunners</id>
+						<phase>validate</phase>
+						<goals>
+							<goal>generateRunners</goal>
+						</goals>
+						<configuration>
+							<glue>foo, bar</glue>
+							<cucumberOutputDir>target\cucumber-reports</cucumberOutputDir>
+							<useTestNG>true</useTestNG>
+						</configuration>
+					</execution>
+				</executions>
+			</plugin>
+		</plugins>
+	</build>
+</project>

--- a/src/it/testng/illegal-escape-char/src/test/resources/features/feature1.feature
+++ b/src/it/testng/illegal-escape-char/src/test/resources/features/feature1.feature
@@ -1,0 +1,14 @@
+Feature: Feature1
+
+  Scenario: Generate Junit Runner for each feature file
+    Given I have feature files
+    When I generate Maven sources
+    Then the file "target/generated-test-sources/1IT.java" should exist
+    And it should contain:
+    """
+    @RunWith(Cucumber.class)
+    @CucumberOptions(strict = true, features = {"classpath:features/feature1.feature"}, format = {"json:target/cucumber-reports/1.json",
+    "pretty"}, monochrome = false, tags = {"@complete", "@accepted"}, glue = { "foo", "bar" })
+    public class Parallel01IT {
+    }
+    """

--- a/src/it/testng/illegal-escape-char/verify.groovy
+++ b/src/it/testng/illegal-escape-char/verify.groovy
@@ -1,0 +1,17 @@
+import org.junit.Assert;
+import static org.hamcrest.Matchers.equalToIgnoringWhiteSpace;
+
+File suite01 = new File( basedir, "target/generated-test-sources/cucumber/Parallel01IT.java" );
+
+assert suite01.isFile()
+
+String expected01=
+"""import cucumber.api.CucumberOptions;
+import cucumber.api.testng.AbstractTestNGCucumberTests;
+
+@CucumberOptions(strict = true, features = {"classpath:features/feature1.feature"}, format = {"json:target/cucumber-reports/1.json",
+"pretty"}, monochrome = false, tags = {"@complete", "@accepted"}, glue = { "foo", "bar" })
+public class Parallel01IT extends AbstractTestNGCucumberTests {
+}"""
+
+Assert.assertThat(suite01.text, equalToIgnoringWhiteSpace(expected01))

--- a/src/it/testng/multiple-format/pom.xml
+++ b/src/it/testng/multiple-format/pom.xml
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+
+	<groupId>com.github.timm-permeance.it</groupId>
+	<artifactId>simple-it</artifactId>
+	<version>1.0-SNAPSHOT</version>
+
+	<description>Output test report in multiple formats</description>
+
+	<properties>
+		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+		<cucumber.version>1.1.8</cucumber.version>
+	</properties>
+
+	<dependencies>
+		<dependency>
+			<groupId>info.cukes</groupId>
+			<artifactId>cucumber-testng</artifactId>
+			<version>${cucumber.version}</version>
+		</dependency>
+		<dependency>
+			<groupId>info.cukes</groupId>
+			<artifactId>cucumber-java</artifactId>
+			<version>${cucumber.version}</version>
+		</dependency>
+	</dependencies>
+
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>@project.groupId@</groupId>
+				<artifactId>@project.artifactId@</artifactId>
+				<version>@project.version@</version>
+				<executions>
+					<execution>
+						<id>generateRunners</id>
+						<phase>validate</phase>
+						<goals>
+							<goal>generateRunners</goal>
+						</goals>
+					</execution>
+				</executions>
+				<configuration>
+					<glue>foo</glue>
+					<format>html,json</format>
+					<useTestNG>true</useTestNG>
+				</configuration>
+			</plugin>
+		</plugins>
+	</build>
+</project>

--- a/src/it/testng/multiple-format/src/test/resources/features/feature1.feature
+++ b/src/it/testng/multiple-format/src/test/resources/features/feature1.feature
@@ -1,0 +1,14 @@
+Feature: Feature1
+
+  Scenario: Generate Junit Runner for each feature file
+    Given I have feature files
+    When I generate Maven sources
+    Then the file "target/generated-test-sources/1IT.java" should exist
+    And it should contain:
+    """
+    @RunWith(Cucumber.class)
+    @CucumberOptions(strict = true, features = {"classpath:features/feature1.feature"}, format = {"json:target/cucumber-parallel/1.json",
+    "pretty"}, monochrome = false, tags = {"@complete", "@accepted"}, glue = { "foo", "bar" })
+    public class Parallel01IT {
+    }
+    """

--- a/src/it/testng/multiple-format/src/test/resources/features/feature2.feature
+++ b/src/it/testng/multiple-format/src/test/resources/features/feature2.feature
@@ -1,0 +1,14 @@
+Feature: Feature1
+
+  Scenario: Generate Junit Runner for each feature file
+    Given I have feature files
+    When I generate Maven sources
+    Then the file "target/generated-test-sources/1IT.java" should exist
+    And it should contain:
+    """
+    @RunWith(Cucumber.class)
+    @CucumberOptions(strict = true, features = {"classpath:features/feature2.feature"}, format = {"json:target/cucumber-parallel/2.json",
+    "pretty"}, monochrome = false, tags = {"@complete", "@accepted"}, glue = { "foo", "bar" })
+    public class Parallel02IT {
+    }
+    """

--- a/src/it/testng/multiple-format/verify.groovy
+++ b/src/it/testng/multiple-format/verify.groovy
@@ -1,0 +1,37 @@
+import org.junit.Assert;
+import static org.hamcrest.Matchers.equalToIgnoringWhiteSpace;
+
+File suite01 = new File( basedir, "target/generated-test-sources/cucumber/Parallel01IT.java" );
+File suite02 = new File( basedir, "target/generated-test-sources/cucumber/Parallel02IT.java" );
+
+assert suite01.isFile()
+assert suite02.isFile()
+
+String expected01=
+"""import cucumber.api.CucumberOptions;
+import cucumber.api.testng.AbstractTestNGCucumberTests;
+
+@CucumberOptions(strict = true, features = {"classpath:features/feature1.feature"}, format = {"html:target/cucumber-parallel/1.html", "json:target/cucumber-parallel/1.json",
+"pretty"}, monochrome = false, tags = {"@complete", "@accepted"}, glue = { "foo" })
+public class Parallel01IT extends AbstractTestNGCucumberTests {
+}"""
+
+String expected02=
+"""import cucumber.api.CucumberOptions;
+import cucumber.api.testng.AbstractTestNGCucumberTests;
+
+@CucumberOptions(strict = true, features = {"classpath:features/feature2.feature"}, format = {"html:target/cucumber-parallel/2.html", "json:target/cucumber-parallel/2.json",
+"pretty"}, monochrome = false, tags = {"@complete", "@accepted"}, glue = { "foo" })
+public class Parallel02IT extends AbstractTestNGCucumberTests {
+}"""
+
+// Depending on the OS, listFiles can list files in different order.  The actual order of files isn't necessary
+
+if(suite01.text.contains("feature1") ){
+	Assert.assertThat(suite01.text, equalToIgnoringWhiteSpace(expected01))
+	Assert.assertThat(suite02.text, equalToIgnoringWhiteSpace(expected02))
+}else{
+	Assert.assertThat(suite02.text, equalToIgnoringWhiteSpace(expected01))
+	Assert.assertThat(suite01.text, equalToIgnoringWhiteSpace(expected02))
+}
+

--- a/src/it/testng/output-directory/pom.xml
+++ b/src/it/testng/output-directory/pom.xml
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+
+	<groupId>com.github.timm-permeance.it</groupId>
+	<artifactId>simple-it</artifactId>
+	<version>1.0-SNAPSHOT</version>
+
+	<description>Output results to a custom directory</description>
+
+	<properties>
+		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+		<cucumber.version>1.1.8</cucumber.version>
+	</properties>
+
+	<dependencies>
+		<dependency>
+			<groupId>info.cukes</groupId>
+			<artifactId>cucumber-testng</artifactId>
+			<version>${cucumber.version}</version>
+		</dependency>
+		<dependency>
+			<groupId>info.cukes</groupId>
+			<artifactId>cucumber-java</artifactId>
+			<version>${cucumber.version}</version>
+		</dependency>
+	</dependencies>
+
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>@project.groupId@</groupId>
+				<artifactId>@project.artifactId@</artifactId>
+				<version>@project.version@</version>
+				<executions>
+					<execution>
+						<id>generateRunners</id>
+						<phase>validate</phase>
+						<goals>
+							<goal>generateRunners</goal>
+						</goals>
+					</execution>
+				</executions>
+				<configuration>
+					<glue>foo, bar</glue>
+					<cucumberOutputDir>target/my-custom-dir</cucumberOutputDir>
+					<useTestNG>true</useTestNG>
+				</configuration>
+			</plugin>
+		</plugins>
+	</build>
+</project>

--- a/src/it/testng/output-directory/src/test/resources/features/feature1.feature
+++ b/src/it/testng/output-directory/src/test/resources/features/feature1.feature
@@ -1,0 +1,14 @@
+Feature: Feature1
+
+  Scenario: Generate Junit Runner for each feature file
+    Given I have feature files
+    When I generate Maven sources
+    Then the file "target/generated-test-sources/1IT.java" should exist
+    And it should contain:
+    """
+    @RunWith(Cucumber.class)
+    @CucumberOptions(strict = true, features = {"classpath:features/feature1.feature"}, format = {"json:target/cucumber-parallel/1.json",
+    "pretty"}, monochrome = false, tags = {"@complete", "@accepted"}, glue = { "foo", "bar" })
+    public class Parallel01IT {
+    }
+    """

--- a/src/it/testng/output-directory/src/test/resources/features/feature2.feature
+++ b/src/it/testng/output-directory/src/test/resources/features/feature2.feature
@@ -1,0 +1,14 @@
+Feature: Feature1
+
+  Scenario: Generate Junit Runner for each feature file
+    Given I have feature files
+    When I generate Maven sources
+    Then the file "target/generated-test-sources/1IT.java" should exist
+    And it should contain:
+    """
+    @RunWith(Cucumber.class)
+    @CucumberOptions(strict = true, features = {"classpath:features/feature2.feature"}, format = {"json:target/cucumber-parallel/2.json",
+    "pretty"}, monochrome = false, tags = {"@complete", "@accepted"}, glue = { "foo", "bar" })
+    public class Parallel02IT {
+    }
+    """

--- a/src/it/testng/output-directory/verify.groovy
+++ b/src/it/testng/output-directory/verify.groovy
@@ -1,0 +1,39 @@
+import org.junit.Assert;
+import static org.hamcrest.Matchers.equalToIgnoringWhiteSpace;
+
+File suite01 = new File( basedir, "target/generated-test-sources/cucumber/Parallel01IT.java" );
+File suite02 = new File( basedir, "target/generated-test-sources/cucumber/Parallel02IT.java" );
+
+assert suite01.isFile()
+assert suite02.isFile()
+
+String expected01=
+"""import cucumber.api.CucumberOptions;
+import cucumber.api.testng.AbstractTestNGCucumberTests;
+
+@CucumberOptions(strict = true, features = {"classpath:features/feature1.feature"}, format = {"json:target/my-custom-dir/1.json",
+	"pretty"}, monochrome = false, tags = {"@complete", "@accepted"}, glue = { "foo", "bar" })
+public class Parallel01IT extends AbstractTestNGCucumberTests {
+}"""
+
+String expected02=
+"""import cucumber.api.CucumberOptions;
+import cucumber.api.testng.AbstractTestNGCucumberTests;
+
+@CucumberOptions(strict = true, features = {"classpath:features/feature2.feature"}, format = {"json:target/my-custom-dir/2.json",
+"pretty"}, monochrome = false, tags = {"@complete", "@accepted"}, glue = { "foo", "bar" })
+public class Parallel02IT extends AbstractTestNGCucumberTests {
+}"""
+
+// Depending on the OS, listFiles can list files in different order.  The actual order of files isn't necessary
+
+if(suite01.text.contains("feature1") ){
+	System.out.println(suite01.text)
+	System.out.println(suite02.text)
+	Assert.assertThat(suite01.text, equalToIgnoringWhiteSpace(expected01))
+	Assert.assertThat(suite02.text, equalToIgnoringWhiteSpace(expected02))
+}else{
+	Assert.assertThat(suite02.text, equalToIgnoringWhiteSpace(expected01))
+	Assert.assertThat(suite01.text, equalToIgnoringWhiteSpace(expected02))
+}
+

--- a/src/it/testng/simple-it/pom.xml
+++ b/src/it/testng/simple-it/pom.xml
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+
+	<groupId>com.github.timm-permeance.it</groupId>
+	<artifactId>simple-it</artifactId>
+	<version>1.0-SNAPSHOT</version>
+
+	<description>A simple IT verifying the basic use case.</description>
+
+	<properties>
+		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+		<cucumber.version>1.1.8</cucumber.version>
+	</properties>
+
+	<dependencies>
+		<dependency>
+			<groupId>info.cukes</groupId>
+			<artifactId>cucumber-testng</artifactId>
+			<version>${cucumber.version}</version>
+		</dependency>
+		<dependency>
+			<groupId>info.cukes</groupId>
+			<artifactId>cucumber-java</artifactId>
+			<version>${cucumber.version}</version>
+		</dependency>
+	</dependencies>
+
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>@project.groupId@</groupId>
+				<artifactId>@project.artifactId@</artifactId>
+				<version>@project.version@</version>
+				<executions>
+					<execution>
+						<id>generateRunners</id>
+						<phase>validate</phase>
+						<goals>
+							<goal>generateRunners</goal>
+						</goals>
+						<configuration>
+							<glue>foo, bar</glue>
+							<useTestNG>true</useTestNG>
+						</configuration>
+					</execution>
+				</executions>
+			</plugin>
+		</plugins>
+	</build>
+</project>

--- a/src/it/testng/simple-it/src/test/resources/features/feature1.feature
+++ b/src/it/testng/simple-it/src/test/resources/features/feature1.feature
@@ -1,0 +1,13 @@
+Feature: Feature1
+
+  Scenario: Generate TestNG Runner for each feature file
+    Given I have feature files
+    When I generate Maven sources
+    Then the file "target/generated-test-sources/1IT.java" should exist
+    And it should contain:
+    """
+    @CucumberOptions(strict = true, features = {"classpath:features/feature1.feature"}, format = {"json:target/cucumber-parallel/1.json",
+    "pretty"}, monochrome = false, tags = {"@complete", "@accepted"}, glue = { "foo", "bar" })
+    public class Parallel01IT extends AbstractTestNGCucumberTests {
+    }
+    """

--- a/src/it/testng/simple-it/src/test/resources/features/feature2.feature
+++ b/src/it/testng/simple-it/src/test/resources/features/feature2.feature
@@ -1,0 +1,13 @@
+Feature: Feature1
+
+  Scenario: Generate TestNG Runner for each feature file
+    Given I have feature files
+    When I generate Maven sources
+    Then the file "target/generated-test-sources/1IT.java" should exist
+    And it should contain:
+    """
+    @CucumberOptions(strict = true, features = {"classpath:features/feature1.feature"}, format = {"json:target/cucumber-parallel/1.json",
+    "pretty"}, monochrome = false, tags = {"@complete", "@accepted"}, glue = { "foo", "bar" })
+    public class Parallel01IT extends AbstractTestNGCucumberTests {
+    }
+    """

--- a/src/it/testng/simple-it/verify.groovy
+++ b/src/it/testng/simple-it/verify.groovy
@@ -1,0 +1,37 @@
+import org.junit.Assert;
+import static org.hamcrest.Matchers.equalToIgnoringWhiteSpace;
+
+File suite01 = new File( basedir, "target/generated-test-sources/cucumber/Parallel01IT.java" );
+File suite02 = new File( basedir, "target/generated-test-sources/cucumber/Parallel02IT.java" );
+
+assert suite01.isFile()
+assert suite02.isFile()
+
+String expected01=
+"""import cucumber.api.CucumberOptions;
+import cucumber.api.testng.AbstractTestNGCucumberTests;
+
+@CucumberOptions(strict = true, features = {"classpath:features/feature1.feature"}, format = {"json:target/cucumber-parallel/1.json",
+"pretty"}, monochrome = false, tags = {"@complete", "@accepted"}, glue = { "foo", "bar" })
+public class Parallel01IT extends AbstractTestNGCucumberTests {
+}"""
+
+String expected02=
+"""import cucumber.api.CucumberOptions;
+import cucumber.api.testng.AbstractTestNGCucumberTests;
+
+@CucumberOptions(strict = true, features = {"classpath:features/feature2.feature"}, format = {"json:target/cucumber-parallel/2.json",
+"pretty"}, monochrome = false, tags = {"@complete", "@accepted"}, glue = { "foo", "bar" })
+public class Parallel02IT extends AbstractTestNGCucumberTests {
+}"""
+
+// Depending on the OS, listFiles can list files in different order.  The actual order of files isn't necessary
+
+if(suite01.text.contains("feature1") ){
+	Assert.assertThat(suite01.text, equalToIgnoringWhiteSpace(expected01))
+	Assert.assertThat(suite02.text, equalToIgnoringWhiteSpace(expected02))
+}else{
+	Assert.assertThat(suite02.text, equalToIgnoringWhiteSpace(expected01))
+	Assert.assertThat(suite01.text, equalToIgnoringWhiteSpace(expected02))
+}
+

--- a/src/main/java/com/github/timm/cucumber/generate/CucumberITGenerator.java
+++ b/src/main/java/com/github/timm/cucumber/generate/CucumberITGenerator.java
@@ -37,8 +37,13 @@ public class CucumberITGenerator {
                 "org.apache.velocity.runtime.resource.loader.ClasspathResourceLoader");
         final VelocityEngine engine = new VelocityEngine(props);
         engine.init();
-        velocityTemplate = engine.getTemplate("cucumber-junit-runner.vm",
-                config.getEncoding());
+        if (config.useTestNG()){
+            velocityTemplate = engine.getTemplate("cucumber-testng-runner.vm",
+                                                  config.getEncoding());
+        } else {
+            velocityTemplate = engine.getTemplate("cucumber-junit-runner.vm",
+                                                  config.getEncoding());
+        }
     }
 
     void generateCucumberITFiles(final File outputDirectory, final Collection<File> featureFiles)

--- a/src/main/java/com/github/timm/cucumber/generate/FileGeneratorConfig.java
+++ b/src/main/java/com/github/timm/cucumber/generate/FileGeneratorConfig.java
@@ -16,4 +16,6 @@ public interface FileGeneratorConfig {
 
     String getCucumberOutputDir();
 
+    boolean useTestNG();
+
 }

--- a/src/main/java/com/github/timm/cucumber/generate/GenerateRunnersMojo.java
+++ b/src/main/java/com/github/timm/cucumber/generate/GenerateRunnersMojo.java
@@ -106,6 +106,10 @@ public class GenerateRunnersMojo extends AbstractMojo implements FileGeneratorCo
     @Parameter(defaultValue = "false", property = "cucumber.tags.filterOutput", required = true)
     private boolean filterFeaturesByTags;
 
+
+    @Parameter(defaultValue = "false", property = "useTestNG", required = true)
+    private boolean useTestNG;
+
     /**
      * @see CucumberOptions
      */
@@ -177,6 +181,10 @@ public class GenerateRunnersMojo extends AbstractMojo implements FileGeneratorCo
 
     public String getCucumberOutputDir() {
         return cucumberOutputDir;
+    }
+
+    public boolean useTestNG() {
+        return useTestNG;
     }
 
 

--- a/src/main/resources/cucumber-testng-runner.vm
+++ b/src/main/resources/cucumber-testng-runner.vm
@@ -1,0 +1,11 @@
+import cucumber.api.CucumberOptions;
+import cucumber.api.testng.AbstractTestNGCucumberTests;
+
+@CucumberOptions(strict = $strict,
+    features = {"classpath:$featureFile"},
+    format = {$reports, "pretty"},
+    monochrome = ${monochrome},
+    tags = {$tags},
+    glue = { $glue })
+public class Parallel${fileCounter}IT extends AbstractTestNGCucumberTests {
+}


### PR DESCRIPTION
Hi, 
I've added posibillty of generating TestNG runners instead of JUnit.
I know I'm missing documentation in readme. 
I will add it add it and in the meantime you can review the code.
Integration tests are copied and modified from junit ones that verify content of generated files.