### PR TITLE
fix ClassNotFound exception at runtime when using namingScheme=feature-title

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -61,6 +61,11 @@
 			<version>1.3</version>
 			<scope>test</scope>
 		</dependency>
+		<dependency>
+			<groupId>com.google.guava</groupId>
+			<artifactId>guava</artifactId>
+			<version>19.0</version>
+		</dependency>
 	</dependencies>
 
 	<dependencyManagement>


### PR DESCRIPTION
In previous PR #15 , I relied only on unit/integration tests to validate the change. Now that it has been released, I tried it, and unfortunately, there's a problem : Google Guava dependency was missed in pom.xml, making it crash at runtime.
It worked in tests because there's a version of Guava that comes from Maven core : I guess it got used during test executions