### PR TITLE
now the junit tests have a class name that matches their file name ->…

### DIFF
--- a/src/it/junit/issue_15-feature-naming-scheme/verify.groovy
+++ b/src/it/junit/issue_15-feature-naming-scheme/verify.groovy
@@ -1,8 +1,8 @@
 import org.junit.Assert;
 import static org.hamcrest.Matchers.equalToIgnoringWhiteSpace;
 
-File suite01 = new File( basedir, "target/generated-test-sources/cucumber/Feature101.java" );
-File suite02 = new File( basedir, "target/generated-test-sources/cucumber/Feature202.java" );
+File suite01 = new File( basedir, "target/generated-test-sources/cucumber/Feature101IT.java" );
+File suite02 = new File( basedir, "target/generated-test-sources/cucumber/Feature202IT.java" );
 
 assert suite01.isFile()
 assert suite02.isFile()
@@ -16,7 +16,7 @@ import cucumber.api.junit.Cucumber;
 @RunWith(Cucumber.class)
 @CucumberOptions(strict = true, features = {"classpath:features/feature1.feature"}, format = {"json:target/cucumber-parallel/1.json",
 "pretty"}, monochrome = false, tags = {"@complete", "@accepted"}, glue = { "foo", "bar" })
-public class Feature101 {
+public class Feature101IT {
 }"""
 
 String expected02=
@@ -28,7 +28,7 @@ import cucumber.api.junit.Cucumber;
 @RunWith(Cucumber.class)
 @CucumberOptions(strict = true, features = {"classpath:features/feature2.feature"}, format = {"json:target/cucumber-parallel/2.json",
 "pretty"}, monochrome = false, tags = {"@complete", "@accepted"}, glue = { "foo", "bar" })
-public class Feature202 {
+public class Feature202IT {
 }"""
 
 // Depending on the OS, listFiles can list files in different order.  The actual order of files isn't necessary

--- a/src/main/java/com/github/timm/cucumber/generate/CucumberITGenerator.java
+++ b/src/main/java/com/github/timm/cucumber/generate/CucumberITGenerator.java
@@ -9,6 +9,7 @@ import java.util.List;
 import java.util.Properties;
 
 import org.apache.commons.io.FileUtils;
+import org.apache.commons.io.FilenameUtils;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.velocity.Template;
 import org.apache.velocity.VelocityContext;
@@ -24,6 +25,7 @@ public class CucumberITGenerator {
     private String featureFileLocation;
     private Template velocityTemplate;
     private ClassNameGenerator classNameGenerator=new ClassNameGenerator();
+    private String outputFileName;
 
 
 
@@ -56,8 +58,6 @@ public class CucumberITGenerator {
             if (shouldSkipFile(file)) {
                 continue;
             }
-
-            final String outputFileName;
 
             if(config.getNamingScheme().equals("simple")){
                 outputFileName = classNameGenerator.generateSimpleClassName(fileCounter);
@@ -171,11 +171,14 @@ public class CucumberITGenerator {
         context.put("strict", overriddenParameters.isStrict());
         context.put("featureFile", featureFileLocation);
         context.put("reports", createFormatStrings());
-        context.put("fileCounter", String.format("%02d", fileCounter));
         context.put("tags", overriddenParameters.getTags());
         context.put("monochrome", overriddenParameters.isMonochrome());
         context.put("cucumberOutputDir", config.getCucumberOutputDir());
         context.put("glue", quoteGlueStrings());
+        //required for testNg template
+        context.put("fileCounter", String.format("%02d", fileCounter));
+        //required for junit template
+        context.put("className", FilenameUtils.removeExtension(outputFileName));
 
         velocityTemplate.merge(context, writer);
     }

--- a/src/main/resources/cucumber-junit-runner.vm
+++ b/src/main/resources/cucumber-junit-runner.vm
@@ -10,5 +10,5 @@ import cucumber.api.junit.Cucumber;
     monochrome = ${monochrome},
     tags = {$tags},
     glue = { $glue })
-public class Parallel${fileCounter}IT {
+public class $className {
 }


### PR DESCRIPTION
… generated java classes can be compiled

modified the tests as per the expected behavior.

now we should be able to close https://github.com/temyers/cucumber-jvm-parallel-plugin/issues/15 