### PR TITLE
Update format to use plugin instead

### DIFF
--- a/src/main/resources/cucumber-junit-runner.vm
+++ b/src/main/resources/cucumber-junit-runner.vm
@@ -6,7 +6,7 @@ import cucumber.api.junit.Cucumber;
 @RunWith(Cucumber.class)
 @CucumberOptions(strict = $strict,
     features = {"classpath:$featureFile"},
-    format = {$reports, "pretty"},
+    plugin = {$reports, "pretty"},
     monochrome = ${monochrome},
     tags = {$tags},
     glue = { $glue })


### PR DESCRIPTION
This will use the plugin option instead of the format option (since its deprecated)