### PR TITLE
Fixed extension for Rerun and Junit reports

### DIFF
--- a/src/main/java/com/github/timm/cucumber/generate/CucumberITGenerator.java
+++ b/src/main/java/com/github/timm/cucumber/generate/CucumberITGenerator.java
@@ -201,12 +201,10 @@ public class CucumberITGenerator {
             } else if(extension.equals("junit")){
                 extension = "xml";
             }
-            //Remove Java extenstion
-            String reportFileName = outputFileName.replace(".java", "");
             
             sb.append(String.format("\"%s:%s/%s.%s\"", formatStr,
                     config.getCucumberOutputDir()
-                    .replace('\\', '/'), reportFileName, extension));
+                    .replace('\\', '/'), fileCounter, extension));
 
             if (i < formatStrs.length - 1) {
                 sb.append(", ");

--- a/src/main/java/com/github/timm/cucumber/generate/CucumberITGenerator.java
+++ b/src/main/java/com/github/timm/cucumber/generate/CucumberITGenerator.java
@@ -196,9 +196,9 @@ public class CucumberITGenerator {
             String extension = formatStr;
             
             //Supported Report Types - https://cucumber.io/docs/reference#reports 
-            if(extension.equals("rerun")){
+            if(extension.equalsIgnoreCase("rerun")){
                 extension = "txt";
-            } else if(extension.equals("junit")){
+            } else if(extension.equalsIgnoreCase("junit")){
                 extension = "xml";
             }
             

--- a/src/main/java/com/github/timm/cucumber/generate/CucumberITGenerator.java
+++ b/src/main/java/com/github/timm/cucumber/generate/CucumberITGenerator.java
@@ -196,6 +196,8 @@ public class CucumberITGenerator {
             String extension = formatStr;
             if(extension.equals("rerun"){
                 extension = "txt";
+            } else if(extension.equals("junit")){
+                extension = "xml";
             }
             sb.append(String.format("\"%s:%s/%s.%s\"", formatStr,
                     config.getCucumberOutputDir()

--- a/src/main/java/com/github/timm/cucumber/generate/CucumberITGenerator.java
+++ b/src/main/java/com/github/timm/cucumber/generate/CucumberITGenerator.java
@@ -193,9 +193,13 @@ public class CucumberITGenerator {
 
         for (int i = 0; i < formatStrs.length; i++) {
             final String formatStr = formatStrs[i].trim();
+            String extension = formatStr;
+            if(extension.equals("rerun"){
+                extension = "txt";
+            }
             sb.append(String.format("\"%s:%s/%s.%s\"", formatStr,
                     config.getCucumberOutputDir()
-                    .replace('\\', '/'), fileCounter, formatStr));
+                    .replace('\\', '/'), fileCounter, extension));
 
             if (i < formatStrs.length - 1) {
                 sb.append(", ");

--- a/src/main/java/com/github/timm/cucumber/generate/CucumberITGenerator.java
+++ b/src/main/java/com/github/timm/cucumber/generate/CucumberITGenerator.java
@@ -194,11 +194,13 @@ public class CucumberITGenerator {
         for (int i = 0; i < formatStrs.length; i++) {
             final String formatStr = formatStrs[i].trim();
             String extension = formatStr;
-            if(extension.equals("rerun"){
+            
+            if(extension.equals("rerun")){
                 extension = "txt";
             } else if(extension.equals("junit")){
                 extension = "xml";
             }
+            
             sb.append(String.format("\"%s:%s/%s.%s\"", formatStr,
                     config.getCucumberOutputDir()
                     .replace('\\', '/'), fileCounter, extension));

--- a/src/main/java/com/github/timm/cucumber/generate/CucumberITGenerator.java
+++ b/src/main/java/com/github/timm/cucumber/generate/CucumberITGenerator.java
@@ -201,10 +201,12 @@ public class CucumberITGenerator {
             } else if(extension.equals("junit")){
                 extension = "xml";
             }
+            //Remove Java extenstion
+            String reportFileName = outputFileName.replace(".java", "");
             
             sb.append(String.format("\"%s:%s/%s.%s\"", formatStr,
                     config.getCucumberOutputDir()
-                    .replace('\\', '/'), outputFileName, extension));
+                    .replace('\\', '/'), reportFileName, extension));
 
             if (i < formatStrs.length - 1) {
                 sb.append(", ");

--- a/src/main/java/com/github/timm/cucumber/generate/CucumberITGenerator.java
+++ b/src/main/java/com/github/timm/cucumber/generate/CucumberITGenerator.java
@@ -201,9 +201,11 @@ public class CucumberITGenerator {
                 extension = "xml";
             }
             
+            String fileName = outputFileName + fileCounter;
+            
             sb.append(String.format("\"%s:%s/%s.%s\"", formatStr,
                     config.getCucumberOutputDir()
-                    .replace('\\', '/'), fileCounter, extension));
+                    .replace('\\', '/'), fileName, extension));
 
             if (i < formatStrs.length - 1) {
                 sb.append(", ");

--- a/src/main/java/com/github/timm/cucumber/generate/CucumberITGenerator.java
+++ b/src/main/java/com/github/timm/cucumber/generate/CucumberITGenerator.java
@@ -195,6 +195,7 @@ public class CucumberITGenerator {
             final String formatStr = formatStrs[i].trim();
             String extension = formatStr;
             
+            //Supported Report Types - https://cucumber.io/docs/reference#reports 
             if(extension.equals("rerun")){
                 extension = "txt";
             } else if(extension.equals("junit")){

--- a/src/main/java/com/github/timm/cucumber/generate/CucumberITGenerator.java
+++ b/src/main/java/com/github/timm/cucumber/generate/CucumberITGenerator.java
@@ -201,11 +201,9 @@ public class CucumberITGenerator {
                 extension = "xml";
             }
             
-            String fileName = outputFileName + fileCounter;
-            
             sb.append(String.format("\"%s:%s/%s.%s\"", formatStr,
                     config.getCucumberOutputDir()
-                    .replace('\\', '/'), fileName, extension));
+                    .replace('\\', '/'), outputFileName, extension));
 
             if (i < formatStrs.length - 1) {
                 sb.append(", ");


### PR DESCRIPTION
Should use .txt for rerun reports (not .rerun). Should use .xml for junit reports (not .junit). Also I updated the report names to use the correlating generated IT file.