### PR TITLE
Fix the maven phase of the code generation

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -20,7 +20,7 @@ Add the following to your POM file:
   <executions>
     <execution>
       <id>generateRunners</id>
-      <phase>validate</phase>
+      <phase>generate-test-sources</phase>
       <goals>
         <goal>generateRunners</goal>
       </goals>

--- a/src/it/junit/custom-output-directory/pom.xml
+++ b/src/it/junit/custom-output-directory/pom.xml
@@ -37,7 +37,7 @@
                 <executions>
                     <execution>
                         <id>generateRunners</id>
-                        <phase>validate</phase>
+                        <phase>generate-test-sources</phase>
                         <goals>
                             <goal>generateRunners</goal>
                         </goals>

--- a/src/it/junit/filter-by-tag/pom.xml
+++ b/src/it/junit/filter-by-tag/pom.xml
@@ -37,7 +37,7 @@
                 <executions>
                     <execution>
                         <id>generateRunners</id>
-                        <phase>validate</phase>
+                        <phase>generate-test-sources</phase>
                         <goals>
                             <goal>generateRunners</goal>
                         </goals>

--- a/src/it/junit/filter-by-tag2-negation/pom.xml
+++ b/src/it/junit/filter-by-tag2-negation/pom.xml
@@ -37,7 +37,7 @@
                 <executions>
                     <execution>
                         <id>generateRunners</id>
-                        <phase>validate</phase>
+                        <phase>generate-test-sources</phase>
                         <goals>
                             <goal>generateRunners</goal>
                         </goals>

--- a/src/it/junit/filter-by-tag3-and/pom.xml
+++ b/src/it/junit/filter-by-tag3-and/pom.xml
@@ -37,7 +37,7 @@
                 <executions>
                     <execution>
                         <id>generateRunners</id>
-                        <phase>validate</phase>
+                        <phase>generate-test-sources</phase>
                         <goals>
                             <goal>generateRunners</goal>
                         </goals>

--- a/src/it/junit/filter-by-tag3-or/pom.xml
+++ b/src/it/junit/filter-by-tag3-or/pom.xml
@@ -37,7 +37,7 @@
                 <executions>
                     <execution>
                         <id>generateRunners</id>
-                        <phase>validate</phase>
+                        <phase>generate-test-sources</phase>
                         <goals>
                             <goal>generateRunners</goal>
                         </goals>

--- a/src/it/junit/filter-by-tag4/pom.xml
+++ b/src/it/junit/filter-by-tag4/pom.xml
@@ -37,7 +37,7 @@
                 <executions>
                     <execution>
                         <id>generateRunners</id>
-                        <phase>validate</phase>
+                        <phase>generate-test-sources</phase>
                         <goals>
                             <goal>generateRunners</goal>
                         </goals>

--- a/src/it/junit/filter-by-tag5-keep-tags-if-no-tags-in-cucumber-opts/pom.xml
+++ b/src/it/junit/filter-by-tag5-keep-tags-if-no-tags-in-cucumber-opts/pom.xml
@@ -38,7 +38,7 @@
                 <executions>
                     <execution>
                         <id>generateRunners</id>
-                        <phase>validate</phase>
+                        <phase>generate-test-sources</phase>
                         <goals>
                             <goal>generateRunners</goal>
                         </goals>

--- a/src/it/junit/filter-by-tag6-override-tags-if-tags-in-cucumber-opts/pom.xml
+++ b/src/it/junit/filter-by-tag6-override-tags-if-tags-in-cucumber-opts/pom.xml
@@ -38,7 +38,7 @@
                 <executions>
                     <execution>
                         <id>generateRunners</id>
-                        <phase>validate</phase>
+                        <phase>generate-test-sources</phase>
                         <goals>
                             <goal>generateRunners</goal>
                         </goals>

--- a/src/it/junit/illegal-escape-char/pom.xml
+++ b/src/it/junit/illegal-escape-char/pom.xml
@@ -37,7 +37,7 @@
                 <executions>
                     <execution>
                         <id>generateRunners</id>
-                        <phase>validate</phase>
+                        <phase>generate-test-sources</phase>
                         <goals>
                             <goal>generateRunners</goal>
                         </goals>

--- a/src/it/junit/issue_15-feature-naming-scheme/pom.xml
+++ b/src/it/junit/issue_15-feature-naming-scheme/pom.xml
@@ -37,7 +37,7 @@
                 <executions>
                     <execution>
                         <id>generateRunners</id>
-                        <phase>validate</phase>
+                        <phase>generate-test-sources</phase>
                         <goals>
                             <goal>generateRunners</goal>
                         </goals>

--- a/src/it/junit/issue_19-complex-naming-scheme/pom.xml
+++ b/src/it/junit/issue_19-complex-naming-scheme/pom.xml
@@ -37,7 +37,7 @@
                 <executions>
                     <execution>
                         <id>generateRunners</id>
-                        <phase>validate</phase>
+                        <phase>generate-test-sources</phase>
                         <goals>
                             <goal>generateRunners</goal>
                         </goals>

--- a/src/it/junit/issue_19-multiple-execution/pom.xml
+++ b/src/it/junit/issue_19-multiple-execution/pom.xml
@@ -37,7 +37,7 @@
                 <executions>
                     <execution>
                         <id>generateRunners</id>
-                        <phase>validate</phase>
+                        <phase>generate-test-sources</phase>
                         <goals>
                             <goal>generateRunners</goal>
                         </goals>
@@ -48,7 +48,7 @@
                     </execution>
                     <execution>
                         <id>generateRunners2</id>
-                        <phase>validate</phase>
+                        <phase>generate-test-sources</phase>
                         <goals>
                             <goal>generateRunners</goal>
                         </goals>

--- a/src/it/junit/issue_50-no-tags/pom.xml
+++ b/src/it/junit/issue_50-no-tags/pom.xml
@@ -37,7 +37,7 @@
                 <executions>
                     <execution>
                         <id>generateRunners</id>
-                        <phase>validate</phase>
+                        <phase>generate-test-sources</phase>
                         <goals>
                             <goal>generateRunners</goal>
                         </goals>

--- a/src/it/junit/multiple-format/pom.xml
+++ b/src/it/junit/multiple-format/pom.xml
@@ -37,7 +37,7 @@
                 <executions>
                     <execution>
                         <id>generateRunners</id>
-                        <phase>validate</phase>
+                        <phase>generate-test-sources</phase>
                         <goals>
                             <goal>generateRunners</goal>
                         </goals>

--- a/src/it/junit/no-features-dir/pom.xml
+++ b/src/it/junit/no-features-dir/pom.xml
@@ -37,7 +37,7 @@
                 <executions>
                     <execution>
                         <id>generateRunners</id>
-                        <phase>validate</phase>
+                        <phase>generate-test-sources</phase>
                         <goals>
                             <goal>generateRunners</goal>
                         </goals>

--- a/src/it/junit/no-glue-specified/pom.xml
+++ b/src/it/junit/no-glue-specified/pom.xml
@@ -37,7 +37,7 @@
                 <executions>
                     <execution>
                         <id>generateRunners</id>
-                        <phase>validate</phase>
+                        <phase>generate-test-sources</phase>
                         <goals>
                             <goal>generateRunners</goal>
                         </goals>

--- a/src/it/junit/simple-it/pom.xml
+++ b/src/it/junit/simple-it/pom.xml
@@ -37,7 +37,7 @@
                 <executions>
                     <execution>
                         <id>generateRunners</id>
-                        <phase>validate</phase>
+                        <phase>generate-test-sources</phase>
                         <goals>
                             <goal>generateRunners</goal>
                         </goals>

--- a/src/it/testng/filter-by-tag/pom.xml
+++ b/src/it/testng/filter-by-tag/pom.xml
@@ -37,7 +37,7 @@
                 <executions>
                     <execution>
                         <id>generateRunners</id>
-                        <phase>validate</phase>
+                        <phase>generate-test-sources</phase>
                         <goals>
                             <goal>generateRunners</goal>
                         </goals>

--- a/src/it/testng/filter-by-tag5-keep-tags-if-no-tags-in-cucumber-opts/pom.xml
+++ b/src/it/testng/filter-by-tag5-keep-tags-if-no-tags-in-cucumber-opts/pom.xml
@@ -38,7 +38,7 @@
                 <executions>
                     <execution>
                         <id>generateRunners</id>
-                        <phase>validate</phase>
+                        <phase>generate-test-sources</phase>
                         <goals>
                             <goal>generateRunners</goal>
                         </goals>

--- a/src/it/testng/filter-by-tag6-override-tags-if-tags-in-cucumber-opts/pom.xml
+++ b/src/it/testng/filter-by-tag6-override-tags-if-tags-in-cucumber-opts/pom.xml
@@ -38,7 +38,7 @@
                 <executions>
                     <execution>
                         <id>generateRunners</id>
-                        <phase>validate</phase>
+                        <phase>generate-test-sources</phase>
                         <goals>
                             <goal>generateRunners</goal>
                         </goals>

--- a/src/it/testng/illegal-escape-char/pom.xml
+++ b/src/it/testng/illegal-escape-char/pom.xml
@@ -37,7 +37,7 @@
                 <executions>
                     <execution>
                         <id>generateRunners</id>
-                        <phase>validate</phase>
+                        <phase>generate-test-sources</phase>
                         <goals>
                             <goal>generateRunners</goal>
                         </goals>

--- a/src/it/testng/issue_15-feature-naming-scheme/pom.xml
+++ b/src/it/testng/issue_15-feature-naming-scheme/pom.xml
@@ -37,7 +37,7 @@
                 <executions>
                     <execution>
                         <id>generateRunners</id>
-                        <phase>validate</phase>
+                        <phase>generate-test-sources</phase>
                         <goals>
                             <goal>generateRunners</goal>
                         </goals>

--- a/src/it/testng/issue_50-no-tags/pom.xml
+++ b/src/it/testng/issue_50-no-tags/pom.xml
@@ -37,7 +37,7 @@
                 <executions>
                     <execution>
                         <id>generateRunners</id>
-                        <phase>validate</phase>
+                        <phase>generate-test-sources</phase>
                         <goals>
                             <goal>generateRunners</goal>
                         </goals>

--- a/src/it/testng/multiple-format/pom.xml
+++ b/src/it/testng/multiple-format/pom.xml
@@ -37,7 +37,7 @@
                 <executions>
                     <execution>
                         <id>generateRunners</id>
-                        <phase>validate</phase>
+                        <phase>generate-test-sources</phase>
                         <goals>
                             <goal>generateRunners</goal>
                         </goals>

--- a/src/it/testng/output-directory/pom.xml
+++ b/src/it/testng/output-directory/pom.xml
@@ -37,7 +37,7 @@
                 <executions>
                     <execution>
                         <id>generateRunners</id>
-                        <phase>validate</phase>
+                        <phase>generate-test-sources</phase>
                         <goals>
                             <goal>generateRunners</goal>
                         </goals>

--- a/src/it/testng/simple-it/pom.xml
+++ b/src/it/testng/simple-it/pom.xml
@@ -37,7 +37,7 @@
                 <executions>
                     <execution>
                         <id>generateRunners</id>
-                        <phase>validate</phase>
+                        <phase>generate-test-sources</phase>
                         <goals>
                             <goal>generateRunners</goal>
                         </goals>


### PR DESCRIPTION
The "validate" Maven phase is inappropriate for code generation.
The correct phase to use is "generate-test-sources"

See https://maven.apache.org/guides/introduction/introduction-to-the-lifecycle.html#Lifecycle_Reference