### PR TITLE
Feature path and 'pretty' format

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
 
     <groupId>com.github.temyers</groupId>
     <artifactId>cucumber-jvm-parallel-plugin</artifactId>
-    <version>FEATURE-PATH-SNAPSHOT</version>
+    <version>2.0.0-SNAPSHOT</version>
     <packaging>maven-plugin</packaging>
 
     <name>cucumber-jvm-parallel-plugin Maven Plugin</name>

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
 
     <groupId>com.github.temyers</groupId>
     <artifactId>cucumber-jvm-parallel-plugin</artifactId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>FEATURE-PATH-SNAPSHOT</version>
     <packaging>maven-plugin</packaging>
 
     <name>cucumber-jvm-parallel-plugin Maven Plugin</name>

--- a/src/it/junit/custom-output-directory/verify.groovy
+++ b/src/it/junit/custom-output-directory/verify.groovy
@@ -18,7 +18,7 @@ import cucumber.api.CucumberOptions;
 import cucumber.api.junit.Cucumber;
 
 @RunWith(Cucumber.class)
-@CucumberOptions(strict = true, features = {\"""" + feature1.absolutePath + """\"}, plugin = {"json:target/my-custom-dir/1.json"},
+@CucumberOptions(strict = true, features = {"${feature1.absolutePath}"}, plugin = {"json:target/my-custom-dir/1.json"},
 monochrome = false, tags = {"@complete", "@accepted"}, glue = { "foo", "bar" })
 public class Parallel01IT {
 }"""
@@ -30,7 +30,7 @@ import cucumber.api.CucumberOptions;
 import cucumber.api.junit.Cucumber;
 
 @RunWith(Cucumber.class)
-@CucumberOptions(strict = true, features = {\"""" + feature2.absolutePath + """\"}, plugin = {"json:target/my-custom-dir/2.json"},
+@CucumberOptions(strict = true, features = {"${feature2.absolutePath}"}, plugin = {"json:target/my-custom-dir/2.json"},
 monochrome = false, tags = {"@complete", "@accepted"}, glue = { "foo", "bar" })
 public class Parallel02IT {
 }"""

--- a/src/it/junit/custom-output-directory/verify.groovy
+++ b/src/it/junit/custom-output-directory/verify.groovy
@@ -5,6 +5,9 @@ import static org.hamcrest.Matchers.equalToIgnoringWhiteSpace
 File suite01 = new File(basedir, "target/generated-test-sources/cucumber/Parallel01IT.java");
 File suite02 = new File(basedir, "target/generated-test-sources/cucumber/Parallel02IT.java");
 
+File feature1 = new File(basedir, "/src/test/resources/features/feature1.feature");
+File feature2 = new File(basedir, "/src/test/resources/features/feature2.feature");
+
 assert suite01.isFile()
 assert suite02.isFile()
 
@@ -15,8 +18,8 @@ import cucumber.api.CucumberOptions;
 import cucumber.api.junit.Cucumber;
 
 @RunWith(Cucumber.class)
-@CucumberOptions(strict = true, features = {"classpath:features/feature1.feature"}, plugin = {"json:target/my-custom-dir/1.json",
-"pretty"}, monochrome = false, tags = {"@complete", "@accepted"}, glue = { "foo", "bar" })
+@CucumberOptions(strict = true, features = {\"""" + feature1.absolutePath + """\"}, plugin = {"json:target/my-custom-dir/1.json"},
+monochrome = false, tags = {"@complete", "@accepted"}, glue = { "foo", "bar" })
 public class Parallel01IT {
 }"""
 
@@ -27,8 +30,8 @@ import cucumber.api.CucumberOptions;
 import cucumber.api.junit.Cucumber;
 
 @RunWith(Cucumber.class)
-@CucumberOptions(strict = true, features = {"classpath:features/feature2.feature"}, plugin = {"json:target/my-custom-dir/2.json",
-"pretty"}, monochrome = false, tags = {"@complete", "@accepted"}, glue = { "foo", "bar" })
+@CucumberOptions(strict = true, features = {\"""" + feature2.absolutePath + """\"}, plugin = {"json:target/my-custom-dir/2.json"},
+monochrome = false, tags = {"@complete", "@accepted"}, glue = { "foo", "bar" })
 public class Parallel02IT {
 }"""
 

--- a/src/it/junit/filter-by-tag/verify.groovy
+++ b/src/it/junit/filter-by-tag/verify.groovy
@@ -18,7 +18,7 @@ import cucumber.api.CucumberOptions;
 import cucumber.api.junit.Cucumber;
 
 @RunWith(Cucumber.class)
-@CucumberOptions(strict = true, features = {\"""" + feature.absolutePath + """\"}, plugin = {"json:target/cucumber-parallel/1.json"},
+@CucumberOptions(strict = true, features = {"${feature.absolutePath}"}, plugin = {"json:target/cucumber-parallel/1.json"},
 monochrome = false, tags = {"@feature1"}, glue = { "foo", "bar" })
 public class Parallel01IT {
 }"""

--- a/src/it/junit/filter-by-tag/verify.groovy
+++ b/src/it/junit/filter-by-tag/verify.groovy
@@ -5,6 +5,8 @@ import static org.hamcrest.Matchers.equalToIgnoringWhiteSpace
 File suite01 = new File(basedir, "target/generated-test-sources/cucumber/Parallel01IT.java");
 File suite02 = new File(basedir, "target/generated-test-sources/cucumber/Parallel02IT.java");
 
+File feature = new File(basedir, "/src/test/resources/features/feature1.feature");
+
 assert suite01.isFile()
 // Only one file should be created
 assert !suite02.isFile()
@@ -16,8 +18,8 @@ import cucumber.api.CucumberOptions;
 import cucumber.api.junit.Cucumber;
 
 @RunWith(Cucumber.class)
-@CucumberOptions(strict = true, features = {"classpath:features/feature1.feature"}, plugin = {"json:target/cucumber-parallel/1.json",
-"pretty"}, monochrome = false, tags = {"@feature1"}, glue = { "foo", "bar" })
+@CucumberOptions(strict = true, features = {\"""" + feature.absolutePath + """\"}, plugin = {"json:target/cucumber-parallel/1.json"},
+monochrome = false, tags = {"@feature1"}, glue = { "foo", "bar" })
 public class Parallel01IT {
 }"""
 

--- a/src/it/junit/filter-by-tag2-negation/verify.groovy
+++ b/src/it/junit/filter-by-tag2-negation/verify.groovy
@@ -15,5 +15,4 @@ if (suite01.text.contains(expected01)) {
 } else {
     Assert.assertTrue(suite01.text.contains(expected02))
     Assert.assertTrue(suite02.text.contains(expected01))
-
 }

--- a/src/it/junit/filter-by-tag5-keep-tags-if-no-tags-in-cucumber-opts/verify.groovy
+++ b/src/it/junit/filter-by-tag5-keep-tags-if-no-tags-in-cucumber-opts/verify.groovy
@@ -18,7 +18,7 @@ import cucumber.api.CucumberOptions;
 import cucumber.api.junit.Cucumber;
 
 @RunWith(Cucumber.class)
-@CucumberOptions(strict = true, features = {\"""" + feature.absolutePath + """\"}, plugin = {"json:target/cucumber-parallel/1.json"},
+@CucumberOptions(strict = true, features = {"${feature.absolutePath}"}, plugin = {"json:target/cucumber-parallel/1.json"},
 monochrome = false, tags = {"@feature1"}, glue = { "foo", "bar" })
 public class Parallel01IT {
 }"""

--- a/src/it/junit/filter-by-tag5-keep-tags-if-no-tags-in-cucumber-opts/verify.groovy
+++ b/src/it/junit/filter-by-tag5-keep-tags-if-no-tags-in-cucumber-opts/verify.groovy
@@ -5,6 +5,8 @@ import static org.hamcrest.Matchers.equalToIgnoringWhiteSpace
 File suite01 = new File(basedir, "target/generated-test-sources/cucumber/Parallel01IT.java");
 File suite02 = new File(basedir, "target/generated-test-sources/cucumber/Parallel02IT.java");
 
+File feature = new File(basedir, "/src/test/resources/features/feature1.feature");
+
 assert suite01.isFile()
 // Only one file should be created
 assert !suite02.isFile()
@@ -16,8 +18,8 @@ import cucumber.api.CucumberOptions;
 import cucumber.api.junit.Cucumber;
 
 @RunWith(Cucumber.class)
-@CucumberOptions(strict = true, features = {"classpath:features/feature1.feature"}, plugin = {"json:target/cucumber-parallel/1.json",
-"pretty"}, monochrome = false, tags = {"@feature1"}, glue = { "foo", "bar" })
+@CucumberOptions(strict = true, features = {\"""" + feature.absolutePath + """\"}, plugin = {"json:target/cucumber-parallel/1.json"},
+monochrome = false, tags = {"@feature1"}, glue = { "foo", "bar" })
 public class Parallel01IT {
 }"""
 

--- a/src/it/junit/filter-by-tag6-override-tags-if-tags-in-cucumber-opts/verify.groovy
+++ b/src/it/junit/filter-by-tag6-override-tags-if-tags-in-cucumber-opts/verify.groovy
@@ -6,6 +6,9 @@ File suite01 = new File(basedir, "target/generated-test-sources/cucumber/Paralle
 File suite02 = new File(basedir, "target/generated-test-sources/cucumber/Parallel02IT.java");
 File suite03 = new File(basedir, "target/generated-test-sources/cucumber/Parallel03IT.java");
 
+File feature1 = new File(basedir, "/src/test/resources/features/feature1.feature");
+File feature2 = new File(basedir, "/src/test/resources/features/feature2.feature");
+
 assert suite01.isFile()
 assert suite02.isFile()
 // Only two files should be created
@@ -18,8 +21,8 @@ import cucumber.api.CucumberOptions;
 import cucumber.api.junit.Cucumber;
 
 @RunWith(Cucumber.class)
-@CucumberOptions(strict = true, features = {"classpath:features/feature1.feature"}, plugin = {"json:target/cucumber-parallel/1.json",
-"pretty"}, monochrome = false, tags = {"@override"}, glue = { "foo", "bar" })
+@CucumberOptions(strict = true, features = {\"""" + feature1.absolutePath + """\"}, plugin = {"json:target/cucumber-parallel/1.json"},
+monochrome = false, tags = {"@override"}, glue = { "foo", "bar" })
 public class Parallel01IT {
 }"""
 
@@ -32,8 +35,8 @@ import cucumber.api.CucumberOptions;
 import cucumber.api.junit.Cucumber;
 
 @RunWith(Cucumber.class)
-@CucumberOptions(strict = true, features = {"classpath:features/feature2.feature"}, plugin = {"json:target/cucumber-parallel/2.json",
-"pretty"}, monochrome = false, tags = {"@override"}, glue = { "foo", "bar" })
+@CucumberOptions(strict = true, features = {\"""" + feature2.absolutePath + """\"}, plugin = {"json:target/cucumber-parallel/2.json"},
+monochrome = false, tags = {"@override"}, glue = { "foo", "bar" })
 public class Parallel02IT {
 }"""
 

--- a/src/it/junit/filter-by-tag6-override-tags-if-tags-in-cucumber-opts/verify.groovy
+++ b/src/it/junit/filter-by-tag6-override-tags-if-tags-in-cucumber-opts/verify.groovy
@@ -21,7 +21,7 @@ import cucumber.api.CucumberOptions;
 import cucumber.api.junit.Cucumber;
 
 @RunWith(Cucumber.class)
-@CucumberOptions(strict = true, features = {\"""" + feature1.absolutePath + """\"}, plugin = {"json:target/cucumber-parallel/1.json"},
+@CucumberOptions(strict = true, features = {"${feature1.absolutePath}"}, plugin = {"json:target/cucumber-parallel/1.json"},
 monochrome = false, tags = {"@override"}, glue = { "foo", "bar" })
 public class Parallel01IT {
 }"""
@@ -35,7 +35,7 @@ import cucumber.api.CucumberOptions;
 import cucumber.api.junit.Cucumber;
 
 @RunWith(Cucumber.class)
-@CucumberOptions(strict = true, features = {\"""" + feature2.absolutePath + """\"}, plugin = {"json:target/cucumber-parallel/2.json"},
+@CucumberOptions(strict = true, features = {"${feature2.absolutePath}"}, plugin = {"json:target/cucumber-parallel/2.json"},
 monochrome = false, tags = {"@override"}, glue = { "foo", "bar" })
 public class Parallel02IT {
 }"""

--- a/src/it/junit/illegal-escape-char/verify.groovy
+++ b/src/it/junit/illegal-escape-char/verify.groovy
@@ -15,7 +15,7 @@ import cucumber.api.CucumberOptions;
 import cucumber.api.junit.Cucumber;
 
 @RunWith(Cucumber.class)
-@CucumberOptions(strict = true, features = {\"""" + feature.absolutePath + """\"}, plugin = {"json:target/cucumber-reports/1.json"},
+@CucumberOptions(strict = true, features = {"${feature.absolutePath}"}, plugin = {"json:target/cucumber-reports/1.json"},
 monochrome = false, tags = {"@complete", "@accepted"}, glue = { "foo", "bar" })
 public class Parallel01IT {
 }"""

--- a/src/it/junit/illegal-escape-char/verify.groovy
+++ b/src/it/junit/illegal-escape-char/verify.groovy
@@ -4,6 +4,8 @@ import static org.hamcrest.Matchers.equalToIgnoringWhiteSpace
 
 File suite01 = new File(basedir, "target/generated-test-sources/cucumber/Parallel01IT.java");
 
+File feature = new File(basedir, "/src/test/resources/features/feature1.feature");
+
 assert suite01.isFile()
 
 String expected01 =
@@ -13,8 +15,8 @@ import cucumber.api.CucumberOptions;
 import cucumber.api.junit.Cucumber;
 
 @RunWith(Cucumber.class)
-@CucumberOptions(strict = true, features = {"classpath:features/feature1.feature"}, plugin = {"json:target/cucumber-reports/1.json",
-"pretty"}, monochrome = false, tags = {"@complete", "@accepted"}, glue = { "foo", "bar" })
+@CucumberOptions(strict = true, features = {\"""" + feature.absolutePath + """\"}, plugin = {"json:target/cucumber-reports/1.json"},
+monochrome = false, tags = {"@complete", "@accepted"}, glue = { "foo", "bar" })
 public class Parallel01IT {
 }"""
 

--- a/src/it/junit/issue_15-feature-naming-scheme/verify.groovy
+++ b/src/it/junit/issue_15-feature-naming-scheme/verify.groovy
@@ -18,7 +18,7 @@ import cucumber.api.CucumberOptions;
 import cucumber.api.junit.Cucumber;
 
 @RunWith(Cucumber.class)
-@CucumberOptions(strict = true, features = {\"""" + feature1.absolutePath + """\"}, plugin = {"json:target/cucumber-parallel/1.json"},
+@CucumberOptions(strict = true, features = {"${feature1.absolutePath}"}, plugin = {"json:target/cucumber-parallel/1.json"},
 monochrome = false, tags = {"@complete", "@accepted"}, glue = { "foo", "bar" })
 public class Feature101IT {
 }"""
@@ -30,7 +30,7 @@ import cucumber.api.CucumberOptions;
 import cucumber.api.junit.Cucumber;
 
 @RunWith(Cucumber.class)
-@CucumberOptions(strict = true, features = {\"""" + feature2.absolutePath + """\"}, plugin = {"json:target/cucumber-parallel/2.json"},
+@CucumberOptions(strict = true, features = {"${feature2.absolutePath}"}, plugin = {"json:target/cucumber-parallel/2.json"},
 monochrome = false, tags = {"@complete", "@accepted"}, glue = { "foo", "bar" })
 public class Feature202IT {
 }"""

--- a/src/it/junit/issue_15-feature-naming-scheme/verify.groovy
+++ b/src/it/junit/issue_15-feature-naming-scheme/verify.groovy
@@ -5,6 +5,9 @@ import static org.hamcrest.Matchers.equalToIgnoringWhiteSpace
 File suite01 = new File(basedir, "target/generated-test-sources/cucumber/Feature101IT.java");
 File suite02 = new File(basedir, "target/generated-test-sources/cucumber/Feature202IT.java");
 
+File feature1 = new File(basedir, "/src/test/resources/features/feature1.feature");
+File feature2 = new File(basedir, "/src/test/resources/features/feature2.feature");
+
 assert suite01.isFile()
 assert suite02.isFile()
 
@@ -15,8 +18,8 @@ import cucumber.api.CucumberOptions;
 import cucumber.api.junit.Cucumber;
 
 @RunWith(Cucumber.class)
-@CucumberOptions(strict = true, features = {"classpath:features/feature1.feature"}, plugin = {"json:target/cucumber-parallel/1.json",
-"pretty"}, monochrome = false, tags = {"@complete", "@accepted"}, glue = { "foo", "bar" })
+@CucumberOptions(strict = true, features = {\"""" + feature1.absolutePath + """\"}, plugin = {"json:target/cucumber-parallel/1.json"},
+monochrome = false, tags = {"@complete", "@accepted"}, glue = { "foo", "bar" })
 public class Feature101IT {
 }"""
 
@@ -27,8 +30,8 @@ import cucumber.api.CucumberOptions;
 import cucumber.api.junit.Cucumber;
 
 @RunWith(Cucumber.class)
-@CucumberOptions(strict = true, features = {"classpath:features/feature2.feature"}, plugin = {"json:target/cucumber-parallel/2.json",
-"pretty"}, monochrome = false, tags = {"@complete", "@accepted"}, glue = { "foo", "bar" })
+@CucumberOptions(strict = true, features = {\"""" + feature2.absolutePath + """\"}, plugin = {"json:target/cucumber-parallel/2.json"},
+monochrome = false, tags = {"@complete", "@accepted"}, glue = { "foo", "bar" })
 public class Feature202IT {
 }"""
 

--- a/src/it/junit/issue_19-complex-naming-scheme/verify.groovy
+++ b/src/it/junit/issue_19-complex-naming-scheme/verify.groovy
@@ -18,7 +18,7 @@ import cucumber.api.CucumberOptions;
 import cucumber.api.junit.Cucumber;
 
 @RunWith(Cucumber.class)
-@CucumberOptions(strict = true, features = {\"""" + feature1.absolutePath + """\"}, plugin = {"json:target/cucumber-parallel/1.json"},
+@CucumberOptions(strict = true, features = {"${feature1.absolutePath}"}, plugin = {"json:target/cucumber-parallel/1.json"},
 monochrome = false, tags = {"@complete", "@accepted"}, glue = { "foo", "bar" })
 public class FooFeature101IT {
 }"""
@@ -30,7 +30,7 @@ import cucumber.api.CucumberOptions;
 import cucumber.api.junit.Cucumber;
 
 @RunWith(Cucumber.class)
-@CucumberOptions(strict = true, features = {\"""" + feature2.absolutePath + """\"}, plugin = {"json:target/cucumber-parallel/2.json"},
+@CucumberOptions(strict = true, features = {"${feature2.absolutePath}"}, plugin = {"json:target/cucumber-parallel/2.json"},
 monochrome = false, tags = {"@complete", "@accepted"}, glue = { "foo", "bar" })
 public class FooFeature202IT {
 }"""

--- a/src/it/junit/issue_19-complex-naming-scheme/verify.groovy
+++ b/src/it/junit/issue_19-complex-naming-scheme/verify.groovy
@@ -5,6 +5,9 @@ import static org.hamcrest.Matchers.equalToIgnoringWhiteSpace
 File suite01 = new File(basedir, "target/generated-test-sources/cucumber/FooFeature101IT.java");
 File suite02 = new File(basedir, "target/generated-test-sources/cucumber/FooFeature202IT.java");
 
+File feature1 = new File(basedir, "/src/test/resources/features/feature1.feature");
+File feature2 = new File(basedir, "/src/test/resources/features/feature2.feature");
+
 assert suite01.isFile()
 assert suite02.isFile()
 
@@ -15,8 +18,8 @@ import cucumber.api.CucumberOptions;
 import cucumber.api.junit.Cucumber;
 
 @RunWith(Cucumber.class)
-@CucumberOptions(strict = true, features = {"classpath:features/feature1.feature"}, plugin = {"json:target/cucumber-parallel/1.json",
-"pretty"}, monochrome = false, tags = {"@complete", "@accepted"}, glue = { "foo", "bar" })
+@CucumberOptions(strict = true, features = {\"""" + feature1.absolutePath + """\"}, plugin = {"json:target/cucumber-parallel/1.json"},
+monochrome = false, tags = {"@complete", "@accepted"}, glue = { "foo", "bar" })
 public class FooFeature101IT {
 }"""
 
@@ -27,8 +30,8 @@ import cucumber.api.CucumberOptions;
 import cucumber.api.junit.Cucumber;
 
 @RunWith(Cucumber.class)
-@CucumberOptions(strict = true, features = {"classpath:features/feature2.feature"}, plugin = {"json:target/cucumber-parallel/2.json",
-"pretty"}, monochrome = false, tags = {"@complete", "@accepted"}, glue = { "foo", "bar" })
+@CucumberOptions(strict = true, features = {\"""" + feature2.absolutePath + """\"}, plugin = {"json:target/cucumber-parallel/2.json"},
+monochrome = false, tags = {"@complete", "@accepted"}, glue = { "foo", "bar" })
 public class FooFeature202IT {
 }"""
 

--- a/src/it/junit/multiple-format/pom.xml
+++ b/src/it/junit/multiple-format/pom.xml
@@ -46,7 +46,7 @@
                 <configuration>
                     <glue>foo</glue>
                     <tags>"@complete", "@accepted"</tags>
-                    <format>html,json</format>
+                    <format>html,json,pretty</format>
                 </configuration>
             </plugin>
         </plugins>

--- a/src/it/junit/multiple-format/verify.groovy
+++ b/src/it/junit/multiple-format/verify.groovy
@@ -18,7 +18,7 @@ import cucumber.api.CucumberOptions;
 import cucumber.api.junit.Cucumber;
 
 @RunWith(Cucumber.class)
-@CucumberOptions(strict = true, features = {\"""" + feature1.absolutePath + """\"}, plugin = {"html:target/cucumber-parallel/1.html", "json:target/cucumber-parallel/1.json", "pretty"},
+@CucumberOptions(strict = true, features = {"${feature1.absolutePath}"}, plugin = {"html:target/cucumber-parallel/1.html", "json:target/cucumber-parallel/1.json", "pretty"},
 monochrome = false, tags = {"@complete", "@accepted"}, glue = { "foo" })
 public class Parallel01IT {
 }"""
@@ -30,7 +30,7 @@ import cucumber.api.CucumberOptions;
 import cucumber.api.junit.Cucumber;
 
 @RunWith(Cucumber.class)
-@CucumberOptions(strict = true, features = {\"""" + feature2.absolutePath + """\"}, plugin = {"html:target/cucumber-parallel/2.html", "json:target/cucumber-parallel/2.json", "pretty"},
+@CucumberOptions(strict = true, features = {"${feature2.absolutePath}"}, plugin = {"html:target/cucumber-parallel/2.html", "json:target/cucumber-parallel/2.json", "pretty"},
 monochrome = false, tags = {"@complete", "@accepted"}, glue = { "foo" })
 public class Parallel02IT {
 }"""

--- a/src/it/junit/multiple-format/verify.groovy
+++ b/src/it/junit/multiple-format/verify.groovy
@@ -5,6 +5,9 @@ import static org.hamcrest.Matchers.equalToIgnoringWhiteSpace
 File suite01 = new File(basedir, "target/generated-test-sources/cucumber/Parallel01IT.java");
 File suite02 = new File(basedir, "target/generated-test-sources/cucumber/Parallel02IT.java");
 
+File feature1 = new File(basedir, "/src/test/resources/features/feature1.feature");
+File feature2 = new File(basedir, "/src/test/resources/features/feature2.feature");
+
 assert suite01.isFile()
 assert suite02.isFile()
 
@@ -15,8 +18,8 @@ import cucumber.api.CucumberOptions;
 import cucumber.api.junit.Cucumber;
 
 @RunWith(Cucumber.class)
-@CucumberOptions(strict = true, features = {"classpath:features/feature1.feature"}, plugin = {"html:target/cucumber-parallel/1.html", "json:target/cucumber-parallel/1.json",
-"pretty"}, monochrome = false, tags = {"@complete", "@accepted"}, glue = { "foo" })
+@CucumberOptions(strict = true, features = {\"""" + feature1.absolutePath + """\"}, plugin = {"html:target/cucumber-parallel/1.html", "json:target/cucumber-parallel/1.json", "pretty"},
+monochrome = false, tags = {"@complete", "@accepted"}, glue = { "foo" })
 public class Parallel01IT {
 }"""
 
@@ -27,8 +30,8 @@ import cucumber.api.CucumberOptions;
 import cucumber.api.junit.Cucumber;
 
 @RunWith(Cucumber.class)
-@CucumberOptions(strict = true, features = {"classpath:features/feature2.feature"}, plugin = {"html:target/cucumber-parallel/2.html", "json:target/cucumber-parallel/2.json",
-"pretty"}, monochrome = false, tags = {"@complete", "@accepted"}, glue = { "foo" })
+@CucumberOptions(strict = true, features = {\"""" + feature2.absolutePath + """\"}, plugin = {"html:target/cucumber-parallel/2.html", "json:target/cucumber-parallel/2.json", "pretty"},
+monochrome = false, tags = {"@complete", "@accepted"}, glue = { "foo" })
 public class Parallel02IT {
 }"""
 

--- a/src/it/junit/simple-it/verify.groovy
+++ b/src/it/junit/simple-it/verify.groovy
@@ -5,6 +5,9 @@ import static org.hamcrest.Matchers.equalToIgnoringWhiteSpace
 File suite01 = new File(basedir, "target/generated-test-sources/cucumber/Parallel01IT.java");
 File suite02 = new File(basedir, "target/generated-test-sources/cucumber/Parallel02IT.java");
 
+File feature1 = new File(basedir, "/src/test/resources/features/feature1.feature");
+File feature2 = new File(basedir, "/src/test/resources/features/feature2.feature");
+
 assert suite01.isFile()
 assert suite02.isFile()
 
@@ -15,8 +18,8 @@ import cucumber.api.CucumberOptions;
 import cucumber.api.junit.Cucumber;
 
 @RunWith(Cucumber.class)
-@CucumberOptions(strict = true, features = {"classpath:features/feature1.feature"}, plugin = {"json:target/cucumber-parallel/1.json",
-"pretty"}, monochrome = false, tags = {"@complete", "@accepted"}, glue = { "foo", "bar" })
+@CucumberOptions(strict = true, features = {\"""" + feature1.absolutePath + """\"}, plugin = {"json:target/cucumber-parallel/1.json"},
+monochrome = false, tags = {"@complete", "@accepted"}, glue = { "foo", "bar" })
 public class Parallel01IT {
 }"""
 
@@ -27,8 +30,8 @@ import cucumber.api.CucumberOptions;
 import cucumber.api.junit.Cucumber;
 
 @RunWith(Cucumber.class)
-@CucumberOptions(strict = true, features = {"classpath:features/feature2.feature"}, plugin = {"json:target/cucumber-parallel/2.json",
-"pretty"}, monochrome = false, tags = {"@complete", "@accepted"}, glue = { "foo", "bar" })
+@CucumberOptions(strict = true, features = {\"""" + feature2.absolutePath + """\"}, plugin = {"json:target/cucumber-parallel/2.json"},
+monochrome = false, tags = {"@complete", "@accepted"}, glue = { "foo", "bar" })
 public class Parallel02IT {
 }"""
 

--- a/src/it/junit/simple-it/verify.groovy
+++ b/src/it/junit/simple-it/verify.groovy
@@ -18,7 +18,7 @@ import cucumber.api.CucumberOptions;
 import cucumber.api.junit.Cucumber;
 
 @RunWith(Cucumber.class)
-@CucumberOptions(strict = true, features = {\"""" + feature1.absolutePath + """\"}, plugin = {"json:target/cucumber-parallel/1.json"},
+@CucumberOptions(strict = true, features = {"${feature1.absolutePath}"}, plugin = {"json:target/cucumber-parallel/1.json"},
 monochrome = false, tags = {"@complete", "@accepted"}, glue = { "foo", "bar" })
 public class Parallel01IT {
 }"""
@@ -30,7 +30,7 @@ import cucumber.api.CucumberOptions;
 import cucumber.api.junit.Cucumber;
 
 @RunWith(Cucumber.class)
-@CucumberOptions(strict = true, features = {\"""" + feature2.absolutePath + """\"}, plugin = {"json:target/cucumber-parallel/2.json"},
+@CucumberOptions(strict = true, features = {"${feature2.absolutePath}"}, plugin = {"json:target/cucumber-parallel/2.json"},
 monochrome = false, tags = {"@complete", "@accepted"}, glue = { "foo", "bar" })
 public class Parallel02IT {
 }"""

--- a/src/it/testng/filter-by-tag/verify.groovy
+++ b/src/it/testng/filter-by-tag/verify.groovy
@@ -5,6 +5,8 @@ import static org.hamcrest.Matchers.equalToIgnoringWhiteSpace
 File suite01 = new File(basedir, "target/generated-test-sources/cucumber/Parallel01IT.java");
 File suite02 = new File(basedir, "target/generated-test-sources/cucumber/Parallel02IT.java");
 
+File feature = new File(basedir, "/src/test/resources/features/feature1.feature");
+
 assert suite01.isFile()
 // Only one file should be created
 assert !suite02.isFile()
@@ -13,8 +15,8 @@ String expected01 =
         """import cucumber.api.CucumberOptions;
 import cucumber.api.testng.AbstractTestNGCucumberTests;
 
-@CucumberOptions(strict = true, features = {"classpath:features/feature1.feature"}, plugin = {"json:target/cucumber-parallel/1.json",
-"pretty"}, monochrome = false, tags = {"@feature1"}, glue = { "foo", "bar" })
+@CucumberOptions(strict = true, features = {\"""" + feature.absolutePath + """\"}, plugin = {"json:target/cucumber-parallel/1.json"},
+monochrome = false, tags = {"@feature1"}, glue = { "foo", "bar" })
 public class Parallel01IT extends AbstractTestNGCucumberTests {
 }"""
 

--- a/src/it/testng/filter-by-tag/verify.groovy
+++ b/src/it/testng/filter-by-tag/verify.groovy
@@ -15,7 +15,7 @@ String expected01 =
         """import cucumber.api.CucumberOptions;
 import cucumber.api.testng.AbstractTestNGCucumberTests;
 
-@CucumberOptions(strict = true, features = {\"""" + feature.absolutePath + """\"}, plugin = {"json:target/cucumber-parallel/1.json"},
+@CucumberOptions(strict = true, features = {"${feature.absolutePath}"}, plugin = {"json:target/cucumber-parallel/1.json"},
 monochrome = false, tags = {"@feature1"}, glue = { "foo", "bar" })
 public class Parallel01IT extends AbstractTestNGCucumberTests {
 }"""

--- a/src/it/testng/filter-by-tag5-keep-tags-if-no-tags-in-cucumber-opts/verify.groovy
+++ b/src/it/testng/filter-by-tag5-keep-tags-if-no-tags-in-cucumber-opts/verify.groovy
@@ -5,6 +5,8 @@ import static org.hamcrest.Matchers.equalToIgnoringWhiteSpace
 File suite01 = new File(basedir, "target/generated-test-sources/cucumber/Parallel01IT.java");
 File suite02 = new File(basedir, "target/generated-test-sources/cucumber/Parallel02IT.java");
 
+File feature = new File(basedir, "/src/test/resources/features/feature1.feature");
+
 assert suite01.isFile()
 // Only one file should be created
 assert !suite02.isFile()
@@ -13,8 +15,8 @@ String expected01 =
         """import cucumber.api.CucumberOptions;
 import cucumber.api.testng.AbstractTestNGCucumberTests;
 
-@CucumberOptions(strict = true, features = {"classpath:features/feature1.feature"}, plugin = {"json:target/cucumber-parallel/1.json",
-"pretty"}, monochrome = false, tags = {"@feature1"}, glue = { "foo", "bar" })
+@CucumberOptions(strict = true, features = {\"""" + feature.absolutePath + """\"}, plugin = {"json:target/cucumber-parallel/1.json"},
+monochrome = false, tags = {"@feature1"}, glue = { "foo", "bar" })
 public class Parallel01IT extends AbstractTestNGCucumberTests {
 }"""
 

--- a/src/it/testng/filter-by-tag5-keep-tags-if-no-tags-in-cucumber-opts/verify.groovy
+++ b/src/it/testng/filter-by-tag5-keep-tags-if-no-tags-in-cucumber-opts/verify.groovy
@@ -15,7 +15,7 @@ String expected01 =
         """import cucumber.api.CucumberOptions;
 import cucumber.api.testng.AbstractTestNGCucumberTests;
 
-@CucumberOptions(strict = true, features = {\"""" + feature.absolutePath + """\"}, plugin = {"json:target/cucumber-parallel/1.json"},
+@CucumberOptions(strict = true, features = {"${feature.absolutePath}"}, plugin = {"json:target/cucumber-parallel/1.json"},
 monochrome = false, tags = {"@feature1"}, glue = { "foo", "bar" })
 public class Parallel01IT extends AbstractTestNGCucumberTests {
 }"""

--- a/src/it/testng/filter-by-tag6-override-tags-if-tags-in-cucumber-opts/verify.groovy
+++ b/src/it/testng/filter-by-tag6-override-tags-if-tags-in-cucumber-opts/verify.groovy
@@ -6,6 +6,9 @@ File suite01 = new File(basedir, "target/generated-test-sources/cucumber/Paralle
 File suite02 = new File(basedir, "target/generated-test-sources/cucumber/Parallel02IT.java");
 File suite03 = new File(basedir, "target/generated-test-sources/cucumber/Parallel03IT.java");
 
+File feature1 = new File(basedir, "/src/test/resources/features/feature1.feature");
+File feature2 = new File(basedir, "/src/test/resources/features/feature2.feature");
+
 assert suite01.isFile()
 assert suite02.isFile()
 // Only two files should be created
@@ -15,8 +18,8 @@ String expected01 =
         """import cucumber.api.CucumberOptions;
 import cucumber.api.testng.AbstractTestNGCucumberTests;
 
-@CucumberOptions(strict = true, features = {"classpath:features/feature1.feature"}, plugin = {"json:target/cucumber-parallel/1.json",
-"pretty"}, monochrome = false, tags = {"@override"}, glue = { "foo", "bar" })
+@CucumberOptions(strict = true, features = {\"""" + feature1.absolutePath + """\"}, plugin = {"json:target/cucumber-parallel/1.json"},
+monochrome = false, tags = {"@override"}, glue = { "foo", "bar" })
 public class Parallel01IT extends AbstractTestNGCucumberTests {
 }"""
 
@@ -26,8 +29,8 @@ String expected02 =
         """import cucumber.api.CucumberOptions;
 import cucumber.api.testng.AbstractTestNGCucumberTests;
 
-@CucumberOptions(strict = true, features = {"classpath:features/feature2.feature"}, plugin = {"json:target/cucumber-parallel/2.json",
-"pretty"}, monochrome = false, tags = {"@override"}, glue = { "foo", "bar" })
+@CucumberOptions(strict = true, features = {\"""" + feature2.absolutePath + """\"}, plugin = {"json:target/cucumber-parallel/2.json"},
+monochrome = false, tags = {"@override"}, glue = { "foo", "bar" })
 public class Parallel02IT extends AbstractTestNGCucumberTests {
 }"""
 

--- a/src/it/testng/filter-by-tag6-override-tags-if-tags-in-cucumber-opts/verify.groovy
+++ b/src/it/testng/filter-by-tag6-override-tags-if-tags-in-cucumber-opts/verify.groovy
@@ -18,7 +18,7 @@ String expected01 =
         """import cucumber.api.CucumberOptions;
 import cucumber.api.testng.AbstractTestNGCucumberTests;
 
-@CucumberOptions(strict = true, features = {\"""" + feature1.absolutePath + """\"}, plugin = {"json:target/cucumber-parallel/1.json"},
+@CucumberOptions(strict = true, features = {"${feature1.absolutePath}"}, plugin = {"json:target/cucumber-parallel/1.json"},
 monochrome = false, tags = {"@override"}, glue = { "foo", "bar" })
 public class Parallel01IT extends AbstractTestNGCucumberTests {
 }"""
@@ -29,7 +29,7 @@ String expected02 =
         """import cucumber.api.CucumberOptions;
 import cucumber.api.testng.AbstractTestNGCucumberTests;
 
-@CucumberOptions(strict = true, features = {\"""" + feature2.absolutePath + """\"}, plugin = {"json:target/cucumber-parallel/2.json"},
+@CucumberOptions(strict = true, features = {"${feature2.absolutePath}"}, plugin = {"json:target/cucumber-parallel/2.json"},
 monochrome = false, tags = {"@override"}, glue = { "foo", "bar" })
 public class Parallel02IT extends AbstractTestNGCucumberTests {
 }"""

--- a/src/it/testng/illegal-escape-char/verify.groovy
+++ b/src/it/testng/illegal-escape-char/verify.groovy
@@ -4,14 +4,16 @@ import static org.hamcrest.Matchers.equalToIgnoringWhiteSpace
 
 File suite01 = new File(basedir, "target/generated-test-sources/cucumber/Parallel01IT.java");
 
+File feature = new File(basedir, "/src/test/resources/features/feature1.feature");
+
 assert suite01.isFile()
 
 String expected01 =
         """import cucumber.api.CucumberOptions;
 import cucumber.api.testng.AbstractTestNGCucumberTests;
 
-@CucumberOptions(strict = true, features = {"classpath:features/feature1.feature"}, plugin = {"json:target/cucumber-reports/1.json",
-"pretty"}, monochrome = false, tags = {"@complete", "@accepted"}, glue = { "foo", "bar" })
+@CucumberOptions(strict = true, features = {\"""" + feature.absolutePath + """\"}, plugin = {"json:target/cucumber-reports/1.json"},
+monochrome = false, tags = {"@complete", "@accepted"}, glue = { "foo", "bar" })
 public class Parallel01IT extends AbstractTestNGCucumberTests {
 }"""
 

--- a/src/it/testng/illegal-escape-char/verify.groovy
+++ b/src/it/testng/illegal-escape-char/verify.groovy
@@ -12,7 +12,7 @@ String expected01 =
         """import cucumber.api.CucumberOptions;
 import cucumber.api.testng.AbstractTestNGCucumberTests;
 
-@CucumberOptions(strict = true, features = {\"""" + feature.absolutePath + """\"}, plugin = {"json:target/cucumber-reports/1.json"},
+@CucumberOptions(strict = true, features = {"${feature.absolutePath}"}, plugin = {"json:target/cucumber-reports/1.json"},
 monochrome = false, tags = {"@complete", "@accepted"}, glue = { "foo", "bar" })
 public class Parallel01IT extends AbstractTestNGCucumberTests {
 }"""

--- a/src/it/testng/issue_15-feature-naming-scheme/verify.groovy
+++ b/src/it/testng/issue_15-feature-naming-scheme/verify.groovy
@@ -5,22 +5,25 @@ import static org.hamcrest.Matchers.equalToIgnoringWhiteSpace
 File suite01 = new File(basedir, "target/generated-test-sources/cucumber/Feature101IT.java");
 File suite02 = new File(basedir, "target/generated-test-sources/cucumber/Feature202IT.java");
 
+File feature1 = new File(basedir, "/src/test/resources/features/feature1.feature");
+File feature2 = new File(basedir, "/src/test/resources/features/feature2.feature");
+
 assert suite01.isFile()
 assert suite02.isFile()
 
 String expected01 = """import cucumber.api.CucumberOptions;
 import cucumber.api.testng.AbstractTestNGCucumberTests;
 
-@CucumberOptions(strict = true, features = {"classpath:features/feature1.feature"}, plugin = {"json:target/cucumber-parallel/1.json",
-"pretty"}, monochrome = false, tags = {"@complete", "@accepted"}, glue = { "foo", "bar" })
+@CucumberOptions(strict = true, features = {\"""" + feature1.absolutePath + """\"}, plugin = {"json:target/cucumber-parallel/1.json"},
+monochrome = false, tags = {"@complete", "@accepted"}, glue = { "foo", "bar" })
 public class Feature101IT extends AbstractTestNGCucumberTests {
 }"""
 
 String expected02 = """import cucumber.api.CucumberOptions;
 import cucumber.api.testng.AbstractTestNGCucumberTests;
 
-@CucumberOptions(strict = true, features = {"classpath:features/feature2.feature"}, plugin = {"json:target/cucumber-parallel/2.json",
-"pretty"}, monochrome = false, tags = {"@complete", "@accepted"}, glue = { "foo", "bar" })
+@CucumberOptions(strict = true, features = {\"""" + feature2.absolutePath + """\"}, plugin = {"json:target/cucumber-parallel/2.json"},
+monochrome = false, tags = {"@complete", "@accepted"}, glue = { "foo", "bar" })
 public class Feature202IT extends AbstractTestNGCucumberTests {
 }"""
 

--- a/src/it/testng/issue_15-feature-naming-scheme/verify.groovy
+++ b/src/it/testng/issue_15-feature-naming-scheme/verify.groovy
@@ -14,7 +14,7 @@ assert suite02.isFile()
 String expected01 = """import cucumber.api.CucumberOptions;
 import cucumber.api.testng.AbstractTestNGCucumberTests;
 
-@CucumberOptions(strict = true, features = {\"""" + feature1.absolutePath + """\"}, plugin = {"json:target/cucumber-parallel/1.json"},
+@CucumberOptions(strict = true, features = {"${feature1.absolutePath}"}, plugin = {"json:target/cucumber-parallel/1.json"},
 monochrome = false, tags = {"@complete", "@accepted"}, glue = { "foo", "bar" })
 public class Feature101IT extends AbstractTestNGCucumberTests {
 }"""
@@ -22,7 +22,7 @@ public class Feature101IT extends AbstractTestNGCucumberTests {
 String expected02 = """import cucumber.api.CucumberOptions;
 import cucumber.api.testng.AbstractTestNGCucumberTests;
 
-@CucumberOptions(strict = true, features = {\"""" + feature2.absolutePath + """\"}, plugin = {"json:target/cucumber-parallel/2.json"},
+@CucumberOptions(strict = true, features = {"${feature2.absolutePath}"}, plugin = {"json:target/cucumber-parallel/2.json"},
 monochrome = false, tags = {"@complete", "@accepted"}, glue = { "foo", "bar" })
 public class Feature202IT extends AbstractTestNGCucumberTests {
 }"""

--- a/src/it/testng/multiple-format/pom.xml
+++ b/src/it/testng/multiple-format/pom.xml
@@ -46,7 +46,7 @@
                 <configuration>
                     <glue>foo</glue>
                     <tags>"@complete", "@accepted"</tags>
-                    <format>html,json</format>
+                    <format>html,json,pretty</format>
                     <useTestNG>true</useTestNG>
                 </configuration>
             </plugin>

--- a/src/it/testng/multiple-format/verify.groovy
+++ b/src/it/testng/multiple-format/verify.groovy
@@ -15,7 +15,7 @@ String expected01 =
         """import cucumber.api.CucumberOptions;
 import cucumber.api.testng.AbstractTestNGCucumberTests;
 
-@CucumberOptions(strict = true, features = {\"""" + feature1.absolutePath + """\"}, plugin = {"html:target/cucumber-parallel/1.html", "json:target/cucumber-parallel/1.json", "pretty"},
+@CucumberOptions(strict = true, features = {"${feature1.absolutePath}"}, plugin = {"html:target/cucumber-parallel/1.html", "json:target/cucumber-parallel/1.json", "pretty"},
 monochrome = false, tags = {"@complete", "@accepted"}, glue = { "foo" })
 public class Parallel01IT extends AbstractTestNGCucumberTests {
 }"""
@@ -24,7 +24,7 @@ String expected02 =
         """import cucumber.api.CucumberOptions;
 import cucumber.api.testng.AbstractTestNGCucumberTests;
 
-@CucumberOptions(strict = true, features = {\"""" + feature2.absolutePath + """\"}, plugin = {"html:target/cucumber-parallel/2.html", "json:target/cucumber-parallel/2.json", "pretty"},
+@CucumberOptions(strict = true, features = {"${feature2.absolutePath}"}, plugin = {"html:target/cucumber-parallel/2.html", "json:target/cucumber-parallel/2.json", "pretty"},
 monochrome = false, tags = {"@complete", "@accepted"}, glue = { "foo" })
 public class Parallel02IT extends AbstractTestNGCucumberTests {
 }"""

--- a/src/it/testng/multiple-format/verify.groovy
+++ b/src/it/testng/multiple-format/verify.groovy
@@ -5,6 +5,9 @@ import static org.hamcrest.Matchers.equalToIgnoringWhiteSpace
 File suite01 = new File(basedir, "target/generated-test-sources/cucumber/Parallel01IT.java");
 File suite02 = new File(basedir, "target/generated-test-sources/cucumber/Parallel02IT.java");
 
+File feature1 = new File(basedir, "/src/test/resources/features/feature1.feature");
+File feature2 = new File(basedir, "/src/test/resources/features/feature2.feature");
+
 assert suite01.isFile()
 assert suite02.isFile()
 
@@ -12,8 +15,8 @@ String expected01 =
         """import cucumber.api.CucumberOptions;
 import cucumber.api.testng.AbstractTestNGCucumberTests;
 
-@CucumberOptions(strict = true, features = {"classpath:features/feature1.feature"}, plugin = {"html:target/cucumber-parallel/1.html", "json:target/cucumber-parallel/1.json",
-"pretty"}, monochrome = false, tags = {"@complete", "@accepted"}, glue = { "foo" })
+@CucumberOptions(strict = true, features = {\"""" + feature1.absolutePath + """\"}, plugin = {"html:target/cucumber-parallel/1.html", "json:target/cucumber-parallel/1.json", "pretty"},
+monochrome = false, tags = {"@complete", "@accepted"}, glue = { "foo" })
 public class Parallel01IT extends AbstractTestNGCucumberTests {
 }"""
 
@@ -21,8 +24,8 @@ String expected02 =
         """import cucumber.api.CucumberOptions;
 import cucumber.api.testng.AbstractTestNGCucumberTests;
 
-@CucumberOptions(strict = true, features = {"classpath:features/feature2.feature"}, plugin = {"html:target/cucumber-parallel/2.html", "json:target/cucumber-parallel/2.json",
-"pretty"}, monochrome = false, tags = {"@complete", "@accepted"}, glue = { "foo" })
+@CucumberOptions(strict = true, features = {\"""" + feature2.absolutePath + """\"}, plugin = {"html:target/cucumber-parallel/2.html", "json:target/cucumber-parallel/2.json", "pretty"},
+monochrome = false, tags = {"@complete", "@accepted"}, glue = { "foo" })
 public class Parallel02IT extends AbstractTestNGCucumberTests {
 }"""
 

--- a/src/it/testng/output-directory/verify.groovy
+++ b/src/it/testng/output-directory/verify.groovy
@@ -15,7 +15,7 @@ String expected01 =
         """import cucumber.api.CucumberOptions;
 import cucumber.api.testng.AbstractTestNGCucumberTests;
 
-@CucumberOptions(strict = true, features = {\"""" + feature1.absolutePath + """\"}, plugin = {"json:target/my-custom-dir/1.json"},
+@CucumberOptions(strict = true, features = {"${feature1.absolutePath}"}, plugin = {"json:target/my-custom-dir/1.json"},
 monochrome = false, tags = {"@complete", "@accepted"}, glue = { "foo", "bar" })
 public class Parallel01IT extends AbstractTestNGCucumberTests {
 }"""
@@ -24,7 +24,7 @@ String expected02 =
         """import cucumber.api.CucumberOptions;
 import cucumber.api.testng.AbstractTestNGCucumberTests;
 
-@CucumberOptions(strict = true, features = {\"""" + feature2.absolutePath + """\"}, plugin = {"json:target/my-custom-dir/2.json"},
+@CucumberOptions(strict = true, features = {"${feature2.absolutePath}"}, plugin = {"json:target/my-custom-dir/2.json"},
 monochrome = false, tags = {"@complete", "@accepted"}, glue = { "foo", "bar" })
 public class Parallel02IT extends AbstractTestNGCucumberTests {
 }"""

--- a/src/it/testng/output-directory/verify.groovy
+++ b/src/it/testng/output-directory/verify.groovy
@@ -5,6 +5,9 @@ import static org.hamcrest.Matchers.equalToIgnoringWhiteSpace
 File suite01 = new File(basedir, "target/generated-test-sources/cucumber/Parallel01IT.java");
 File suite02 = new File(basedir, "target/generated-test-sources/cucumber/Parallel02IT.java");
 
+File feature1 = new File(basedir, "/src/test/resources/features/feature1.feature");
+File feature2 = new File(basedir, "/src/test/resources/features/feature2.feature");
+
 assert suite01.isFile()
 assert suite02.isFile()
 
@@ -12,8 +15,8 @@ String expected01 =
         """import cucumber.api.CucumberOptions;
 import cucumber.api.testng.AbstractTestNGCucumberTests;
 
-@CucumberOptions(strict = true, features = {"classpath:features/feature1.feature"}, plugin = {"json:target/my-custom-dir/1.json",
-	"pretty"}, monochrome = false, tags = {"@complete", "@accepted"}, glue = { "foo", "bar" })
+@CucumberOptions(strict = true, features = {\"""" + feature1.absolutePath + """\"}, plugin = {"json:target/my-custom-dir/1.json"},
+monochrome = false, tags = {"@complete", "@accepted"}, glue = { "foo", "bar" })
 public class Parallel01IT extends AbstractTestNGCucumberTests {
 }"""
 
@@ -21,16 +24,14 @@ String expected02 =
         """import cucumber.api.CucumberOptions;
 import cucumber.api.testng.AbstractTestNGCucumberTests;
 
-@CucumberOptions(strict = true, features = {"classpath:features/feature2.feature"}, plugin = {"json:target/my-custom-dir/2.json",
-"pretty"}, monochrome = false, tags = {"@complete", "@accepted"}, glue = { "foo", "bar" })
+@CucumberOptions(strict = true, features = {\"""" + feature2.absolutePath + """\"}, plugin = {"json:target/my-custom-dir/2.json"},
+monochrome = false, tags = {"@complete", "@accepted"}, glue = { "foo", "bar" })
 public class Parallel02IT extends AbstractTestNGCucumberTests {
 }"""
 
 // Depending on the OS, listFiles can list files in different order.  The actual order of files isn't necessary
 
 if (suite01.text.contains("feature1")) {
-    System.out.println(suite01.text)
-    System.out.println(suite02.text)
     Assert.assertThat(suite01.text, equalToIgnoringWhiteSpace(expected01))
     Assert.assertThat(suite02.text, equalToIgnoringWhiteSpace(expected02))
 } else {

--- a/src/it/testng/simple-it/verify.groovy
+++ b/src/it/testng/simple-it/verify.groovy
@@ -5,6 +5,9 @@ import static org.hamcrest.Matchers.equalToIgnoringWhiteSpace
 File suite01 = new File(basedir, "target/generated-test-sources/cucumber/Parallel01IT.java");
 File suite02 = new File(basedir, "target/generated-test-sources/cucumber/Parallel02IT.java");
 
+File feature1 = new File(basedir, "/src/test/resources/features/feature1.feature");
+File feature2 = new File(basedir, "/src/test/resources/features/feature2.feature");
+
 assert suite01.isFile()
 assert suite02.isFile()
 
@@ -12,8 +15,8 @@ String expected01 =
         """import cucumber.api.CucumberOptions;
 import cucumber.api.testng.AbstractTestNGCucumberTests;
 
-@CucumberOptions(strict = true, features = {"classpath:features/feature1.feature"}, plugin = {"json:target/cucumber-parallel/1.json",
-"pretty"}, monochrome = false, tags = {"@complete", "@accepted"}, glue = { "foo", "bar" })
+@CucumberOptions(strict = true, features = {\"""" + feature1.absolutePath + """\"}, plugin = {"json:target/cucumber-parallel/1.json"},
+monochrome = false, tags = {"@complete", "@accepted"}, glue = { "foo", "bar" })
 public class Parallel01IT extends AbstractTestNGCucumberTests {
 }"""
 
@@ -21,8 +24,8 @@ String expected02 =
         """import cucumber.api.CucumberOptions;
 import cucumber.api.testng.AbstractTestNGCucumberTests;
 
-@CucumberOptions(strict = true, features = {"classpath:features/feature2.feature"}, plugin = {"json:target/cucumber-parallel/2.json",
-"pretty"}, monochrome = false, tags = {"@complete", "@accepted"}, glue = { "foo", "bar" })
+@CucumberOptions(strict = true, features = {\"""" + feature2.absolutePath + """\"}, plugin = {"json:target/cucumber-parallel/2.json"},
+monochrome = false, tags = {"@complete", "@accepted"}, glue = { "foo", "bar" })
 public class Parallel02IT extends AbstractTestNGCucumberTests {
 }"""
 

--- a/src/it/testng/simple-it/verify.groovy
+++ b/src/it/testng/simple-it/verify.groovy
@@ -15,7 +15,7 @@ String expected01 =
         """import cucumber.api.CucumberOptions;
 import cucumber.api.testng.AbstractTestNGCucumberTests;
 
-@CucumberOptions(strict = true, features = {\"""" + feature1.absolutePath + """\"}, plugin = {"json:target/cucumber-parallel/1.json"},
+@CucumberOptions(strict = true, features = {"${feature1.absolutePath}"}, plugin = {"json:target/cucumber-parallel/1.json"},
 monochrome = false, tags = {"@complete", "@accepted"}, glue = { "foo", "bar" })
 public class Parallel01IT extends AbstractTestNGCucumberTests {
 }"""
@@ -24,7 +24,7 @@ String expected02 =
         """import cucumber.api.CucumberOptions;
 import cucumber.api.testng.AbstractTestNGCucumberTests;
 
-@CucumberOptions(strict = true, features = {\"""" + feature2.absolutePath + """\"}, plugin = {"json:target/cucumber-parallel/2.json"},
+@CucumberOptions(strict = true, features = {"${feature2.absolutePath}"}, plugin = {"json:target/cucumber-parallel/2.json"},
 monochrome = false, tags = {"@complete", "@accepted"}, glue = { "foo", "bar" })
 public class Parallel02IT extends AbstractTestNGCucumberTests {
 }"""

--- a/src/main/java/com/github/timm/cucumber/generate/CucumberITGenerator.java
+++ b/src/main/java/com/github/timm/cucumber/generate/CucumberITGenerator.java
@@ -157,9 +157,7 @@ public class CucumberITGenerator {
      * @param file The feature file
      */
     private void setFeatureFileLocation(final File file) {
-        final File featuresDirectory = config.getFeaturesDirectory();
         featureFileLocation = file.getPath()
-                        .replace(featuresDirectory.getPath(), featuresDirectory.getName())
                         .replace(File.separatorChar, '/');
     }
 

--- a/src/main/java/com/github/timm/cucumber/generate/CucumberITGenerator.java
+++ b/src/main/java/com/github/timm/cucumber/generate/CucumberITGenerator.java
@@ -186,9 +186,14 @@ public class CucumberITGenerator {
 
         for (int i = 0; i < formatStrs.length; i++) {
             final String formatStr = formatStrs[i].trim();
-            sb.append(String.format("\"%s:%s/%s.%s\"", formatStr,
-                            config.getCucumberOutputDir().replace('\\', '/'), fileCounter,
-                            formatStr));
+
+            if ("pretty".equalsIgnoreCase(formatStr)) {
+                sb.append("\"pretty\"");
+            } else {
+                sb.append(String.format("\"%s:%s/%s.%s\"", formatStr,
+                        config.getCucumberOutputDir().replace('\\', '/'), fileCounter,
+                        formatStr));
+            }
 
             if (i < formatStrs.length - 1) {
                 sb.append(", ");

--- a/src/main/resources/cucumber-junit-runner.vm
+++ b/src/main/resources/cucumber-junit-runner.vm
@@ -5,7 +5,7 @@ import cucumber.api.junit.Cucumber;
 
 @RunWith(Cucumber.class)
 @CucumberOptions(strict = $strict,
-features = {"classpath:$featureFile"},
+features = {"$featureFile"},
 plugin = {$reports,},
 monochrome = ${monochrome},
 tags = {#if($tags)$tags#end},

--- a/src/main/resources/cucumber-junit-runner.vm
+++ b/src/main/resources/cucumber-junit-runner.vm
@@ -6,7 +6,7 @@ import cucumber.api.junit.Cucumber;
 @RunWith(Cucumber.class)
 @CucumberOptions(strict = $strict,
 features = {"classpath:$featureFile"},
-plugin = {$reports, "pretty"},
+plugin = {$reports,},
 monochrome = ${monochrome},
 tags = {#if($tags)$tags#end},
 glue = { $glue })

--- a/src/main/resources/cucumber-junit-runner.vm
+++ b/src/main/resources/cucumber-junit-runner.vm
@@ -6,7 +6,7 @@ import cucumber.api.junit.Cucumber;
 @RunWith(Cucumber.class)
 @CucumberOptions(strict = $strict,
 features = {"$featureFile"},
-plugin = {$reports,},
+plugin = {$reports},
 monochrome = ${monochrome},
 tags = {#if($tags)$tags#end},
 glue = { $glue })

--- a/src/main/resources/cucumber-testng-runner.vm
+++ b/src/main/resources/cucumber-testng-runner.vm
@@ -3,7 +3,7 @@ import cucumber.api.testng.AbstractTestNGCucumberTests;
 
 @CucumberOptions(strict = $strict,
 features = {"$featureFile"},
-plugin = {$reports,},
+plugin = {$reports},
 monochrome = ${monochrome},
 tags = {#if($tags)$tags#end},
 glue = { $glue })

--- a/src/main/resources/cucumber-testng-runner.vm
+++ b/src/main/resources/cucumber-testng-runner.vm
@@ -2,8 +2,8 @@ import cucumber.api.CucumberOptions;
 import cucumber.api.testng.AbstractTestNGCucumberTests;
 
 @CucumberOptions(strict = $strict,
-features = {"classpath:$featureFile"},
-plugin = {$reports, "pretty"},
+features = {"$featureFile"},
+plugin = {$reports,},
 monochrome = ${monochrome},
 tags = {#if($tags)$tags#end},
 glue = { $glue })


### PR DESCRIPTION
Hello, I'd like to contribute two changes to your plugin.

The first is rather than referencing 'classpath' in the features property of the Cucumber annotation, I've found the plugin to be more versatile if the entire absolute path is injected. We've got a project of tests where we have multiple subdirectories of groups of tests within src/test/resources/features and we have jobs that are intended to run only a specific group. In short: we need to be able to specify a directory of feature files which may not be at the runtime classpath root. I've tested this on both mac os and windows and everything worked perfectly fine. Hopefully I haven't overlooked any potential issues with this method of specifying the location of the feature file.

The second is being able to configure the plugin to use the 'pretty' format in the plugin property. We generally don't need our test suite printing out so much information since we utilize the maven-cucumber-reporting plugin which will show us the steps in a given test.

I've updated all integrations and they run successfully. I've added the 'pretty' format option to both 'multiple-format' tests. 

Let me know what you think. Thanks!