### PR TITLE
Allow custom templates. Closes #61.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -234,7 +234,6 @@
 		<profile>
 			<id>run-its</id>
 			<build>
-
 				<plugins>
 					<plugin>
 						<groupId>org.apache.maven.plugins</groupId>
@@ -269,7 +268,6 @@
 						</executions>
 					</plugin>
 				</plugins>
-
 			</build>
 		</profile>
 	</profiles>
@@ -337,11 +335,11 @@
 						<!-- Ignore forked code -->
 						<exclude>**/RuntimeOptions.java</exclude>
 					</excludes>
-
 				</configuration>
 			</plugin>
 		</plugins>
 	</reporting>
+
 	<description>Plugin for assisting with running Cucumber-JVM features in parallel</description>
 
 	<developers>

--- a/readme.md
+++ b/readme.md
@@ -25,34 +25,36 @@ Add the following to your POM file:
         <goal>generateRunners</goal>
       </goals>
       <configuration>
-          <!-- Mandatory -->
-          <!-- comma separated list of package names to scan for glue code -->
-         <glue>foo, bar</glue>
-         <!-- These are optional, with the default values -->
-          <!-- Where to output the generated tests -->
-           <outputDirectory>${project.build.directory}/generated-test-sources/cucumber</outputDirectory>
-           <!-- The diectory, which must be in the root of the runtime classpath, containing your feature files.  -->
-          <featuresDirectory>src/test/resources/features/</featuresDirectory>
-           <!-- Directory where the cucumber report files shall be written  -->
-          <cucumberOutputDir>target/cucumber-parallel</cucumberOutputDir>
-          <!-- comma separated list of output formats -->
-         <format>json</format>
-         <!-- CucumberOptions.strict property -->
-         <strict>true</strict>
-         <!-- CucumberOptions.monochrome property -->
-         <monochrome>true</monochrome>
-         <!-- The tags to run, maps to CucumberOptions.tags property -->
-         <tags></tags>
-         <!-- If set to true, only feature files containing the required tags shall be generated. -->
-         <filterFeaturesByTags>false</filterFeaturesByTags>
-         <!-- Generate TestNG runners instead of JUnit ones. --> 
-         <useTestNG>false</useTestNG>
-         <!-- The naming scheme to use for the generated test classes.  One of 'simple' or 'feature-title' --> 
-         <namingScheme>simple</namingScheme>
-         <!-- The class naming pattern to use.  Only required/used if naming scheme is 'pattern'.-->
-         <namingPattern>Parallel{c}IT</namingPattern>
-         <!-- One of [SCENARIO, FEATURE]. SCENARIO generates one runner per scenario.  FEATURE generates a runner per feature. -->
-         <parallelScheme>SCENARIO</parallelScheme>
+        <!-- Mandatory -->
+        <!-- comma separated list of package names to scan for glue code -->
+        <glue>foo, bar</glue>
+        <!-- These are optional, with the default values -->
+        <!-- Where to output the generated tests -->
+        <outputDirectory>${project.build.directory}/generated-test-sources/cucumber</outputDirectory>
+        <!-- The directory, which must be in the root of the runtime classpath, containing your feature files.  -->
+        <featuresDirectory>src/test/resources/features/</featuresDirectory>
+        <!-- Directory where the cucumber report files shall be written  -->
+        <cucumberOutputDir>target/cucumber-parallel</cucumberOutputDir>
+        <!-- comma separated list of output formats -->
+        <format>json</format>
+        <!-- CucumberOptions.strict property -->
+        <strict>true</strict>
+        <!-- CucumberOptions.monochrome property -->
+        <monochrome>true</monochrome>
+        <!-- The tags to run, maps to CucumberOptions.tags property -->
+        <tags></tags>
+        <!-- If set to true, only feature files containing the required tags shall be generated. -->
+        <filterFeaturesByTags>false</filterFeaturesByTags>
+        <!-- Generate TestNG runners instead of JUnit ones. --> 
+        <useTestNG>false</useTestNG>
+        <!-- The naming scheme to use for the generated test classes.  One of 'simple' or 'feature-title' --> 
+        <namingScheme>simple</namingScheme>
+        <!-- The class naming pattern to use.  Only required/used if naming scheme is 'pattern'.-->
+        <namingPattern>Parallel{c}IT</namingPattern>
+        <!-- One of [SCENARIO, FEATURE]. SCENARIO generates one runner per scenario.  FEATURE generates a runner per feature. -->
+        <parallelScheme>SCENARIO</parallelScheme>
+        <!-- Specify a custom template for the generated sources (this is a relative path) -->
+        <customVmTemplate>src/test/resources/cucumber-custom-runner.vm</customVmTemplate>
       </configuration>
     </execution>
   </executions>
@@ -165,8 +167,8 @@ Contributing
 To contribute:
 
 * Create an integration test to demonstrate the behaviour under `src/it/`.  For example, to add support for multiple output formats for junit runners:
-    * Create src/it/junit/multiple-format
-    * copy the contents of the src/it/junit/simple-it directory and update the pom/src as appropriate to demonstrate the configuration.  Update the verify.groovy to implement the test for your feature.
+    * Create `src/it/junit/multiple-format`
+    * copy the contents of the `src/it/junit/simple-it` directory and update the `pom/src` as appropriate to demonstrate the configuration.  Update `verify.groovy` to implement the test for your feature.
     * Run `mvn clean install -Prun-its` to run the integration tests.
 * Implement the feature
 * When all tests are passing, submit a pull request.

--- a/src/it/junit/custom-output-directory/src/test/resources/features/feature2.feature
+++ b/src/it/junit/custom-output-directory/src/test/resources/features/feature2.feature
@@ -1,4 +1,4 @@
-Feature: Feature1
+Feature: Feature2
 
   Scenario: Generate Junit Runner for each feature file
     Given I have feature files

--- a/src/it/junit/custom-output-directory/verify.groovy
+++ b/src/it/junit/custom-output-directory/verify.groovy
@@ -2,11 +2,11 @@ import org.junit.Assert
 
 import static org.hamcrest.Matchers.equalToIgnoringWhiteSpace
 
-File suite01 = new File(basedir, "target/generated-test-sources/cucumber/Parallel01IT.java");
-File suite02 = new File(basedir, "target/generated-test-sources/cucumber/Parallel02IT.java");
+File suite01 = new File(basedir, "target/generated-test-sources/cucumber/Parallel01IT.java")
+File suite02 = new File(basedir, "target/generated-test-sources/cucumber/Parallel02IT.java")
 
-File feature1 = new File(basedir, "/src/test/resources/features/feature1.feature");
-File feature2 = new File(basedir, "/src/test/resources/features/feature2.feature");
+File feature1 = new File(basedir, "/src/test/resources/features/feature1.feature")
+File feature2 = new File(basedir, "/src/test/resources/features/feature2.feature")
 
 assert suite01.isFile()
 assert suite02.isFile()
@@ -35,8 +35,8 @@ monochrome = false, tags = {"@complete", "@accepted"}, glue = { "foo", "bar" })
 public class Parallel02IT {
 }"""
 
-// Depending on the OS, listFiles can list files in different order.  The actual order of files isn't necessary
-
+// The order of the files isn't important but listFiles may list files in any order
+// This ensures we assert correctly despite file ordering
 if (suite01.text.contains("feature1")) {
     Assert.assertThat(suite01.text, equalToIgnoringWhiteSpace(expected01))
     Assert.assertThat(suite02.text, equalToIgnoringWhiteSpace(expected02))

--- a/src/it/junit/custom-template/custom-template-test.vm
+++ b/src/it/junit/custom-template/custom-template-test.vm
@@ -1,0 +1,1 @@
+// This is a custom template for $className

--- a/src/it/junit/custom-template/pom.xml
+++ b/src/it/junit/custom-template/pom.xml
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xmlns="http://maven.apache.org/POM/4.0.0"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>com.github.temyers.it</groupId>
+  <artifactId>custom-template</artifactId>
+  <version>1.0-SNAPSHOT</version>
+
+  <description>Output using a custom velocity template</description>
+
+  <properties>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    <cucumber.version>1.2.2</cucumber.version>
+  </properties>
+
+  <dependencies>
+    <dependency>
+      <groupId>info.cukes</groupId>
+      <artifactId>cucumber-testng</artifactId>
+      <version>${cucumber.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>info.cukes</groupId>
+      <artifactId>cucumber-java</artifactId>
+      <version>${cucumber.version}</version>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>@project.groupId@</groupId>
+        <artifactId>@project.artifactId@</artifactId>
+        <version>@project.version@</version>
+        <executions>
+          <execution>
+            <id>generateRunners</id>
+            <phase>generate-test-sources</phase>
+            <goals>
+              <goal>generateRunners</goal>
+            </goals>
+          </execution>
+        </executions>
+        <configuration>
+          <glue>foo, bar</glue>
+          <customVmTemplate>custom-template-test.vm</customVmTemplate>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/src/it/junit/custom-template/src/test/resources/features/feature1.feature
+++ b/src/it/junit/custom-template/src/test/resources/features/feature1.feature
@@ -1,0 +1,10 @@
+Feature: Feature1
+
+  Scenario: Generate Custom File for each feature file
+    Given I have feature files
+    When I generate Maven sources
+    Then the file "target/generated-test-sources/Parallel01IT.java" should exist
+    And it should contain:
+    """
+    // This is a custom template for Parallel01IT
+    """

--- a/src/it/junit/custom-template/src/test/resources/features/feature2.feature
+++ b/src/it/junit/custom-template/src/test/resources/features/feature2.feature
@@ -1,0 +1,10 @@
+Feature: Feature2
+
+  Scenario: Generate Custom File for each feature file
+    Given I have feature files
+    When I generate Maven sources
+    Then the file "target/generated-test-sources/Parallel02IT.java" should exist
+    And it should contain:
+    """
+    // This is a custom template for Parallel02IT
+    """

--- a/src/it/junit/custom-template/verify.groovy
+++ b/src/it/junit/custom-template/verify.groovy
@@ -1,0 +1,24 @@
+import org.junit.Assert
+
+import static org.hamcrest.Matchers.equalToIgnoringWhiteSpace
+
+def outputPath = "target/generated-test-sources/cucumber/"
+File suite01 = new File(basedir, outputPath + "Parallel01IT.java")
+File suite02 = new File(basedir, outputPath + "Parallel02IT.java")
+
+assert suite01.isFile()
+assert suite02.isFile()
+
+String expected01 = "// This is a custom template for Parallel01IT"
+String expected02 = "// This is a custom template for Parallel02IT"
+
+// The order of the files isn't important but listFiles may list files in any order
+// This ensures we assert correctly despite file ordering
+if (suite01.text.contains("01")) {
+    Assert.assertThat(suite01.text, equalToIgnoringWhiteSpace(expected01))
+    Assert.assertThat(suite02.text, equalToIgnoringWhiteSpace(expected02))
+} else {
+    Assert.assertThat(suite02.text, equalToIgnoringWhiteSpace(expected01))
+    Assert.assertThat(suite01.text, equalToIgnoringWhiteSpace(expected02))
+}
+

--- a/src/main/java/com/github/timm/cucumber/generate/CucumberITGeneratorByFeature.java
+++ b/src/main/java/com/github/timm/cucumber/generate/CucumberITGeneratorByFeature.java
@@ -7,6 +7,7 @@ import gherkin.Parser;
 import gherkin.TokenMatcher;
 import gherkin.ast.Feature;
 import org.apache.commons.io.FilenameUtils;
+import org.apache.commons.lang.StringUtils;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.velocity.Template;
 import org.apache.velocity.VelocityContext;
@@ -33,7 +34,7 @@ public class CucumberITGeneratorByFeature implements CucumberITGenerator {
 
     private final FileGeneratorConfig config;
     private final OverriddenCucumberOptionsParameters overriddenParameters;
-    int fileCounter = 1;
+    private int fileCounter = 1;
     private String featureFileLocation;
     private Template velocityTemplate;
     private String outputFileName;
@@ -58,15 +59,20 @@ public class CucumberITGeneratorByFeature implements CucumberITGenerator {
         final Properties props = new Properties();
         props.put("resource.loader", "class");
         props.put("class.resource.loader.class",
-                        "org.apache.velocity.runtime.resource.loader.ClasspathResourceLoader");
+                "org.apache.velocity.runtime.resource.loader.ClasspathResourceLoader");
+        final String name;
+        if (StringUtils.isNotBlank(config.getCustomVmTemplate())) {
+            // Look for custom template on the classpath or as a relative file path
+            props.put("resource.loader", "class, file");
+            name = config.getCustomVmTemplate();
+        } else if (config.useTestNG()) {
+            name = "cucumber-testng-runner.vm";
+        } else {
+            name = "cucumber-junit-runner.vm";
+        }
         final VelocityEngine engine = new VelocityEngine(props);
         engine.init();
-        if (config.useTestNG()) {
-            velocityTemplate =
-                            engine.getTemplate("cucumber-testng-runner.vm", config.getEncoding());
-        } else {
-            velocityTemplate = engine.getTemplate("cucumber-junit-runner.vm", config.getEncoding());
-        }
+        velocityTemplate = engine.getTemplate(name, config.getEncoding());
     }
 
     /**

--- a/src/main/java/com/github/timm/cucumber/generate/FileGeneratorConfig.java
+++ b/src/main/java/com/github/timm/cucumber/generate/FileGeneratorConfig.java
@@ -22,4 +22,5 @@ public interface FileGeneratorConfig {
 
     String getNamingPattern();
 
+    String getCustomVmTemplate();
 }

--- a/src/main/java/com/github/timm/cucumber/generate/GenerateRunnersMojo.java
+++ b/src/main/java/com/github/timm/cucumber/generate/GenerateRunnersMojo.java
@@ -113,7 +113,6 @@ public class GenerateRunnersMojo extends AbstractMojo implements FileGeneratorCo
     @Parameter(defaultValue = "false", property = "cucumber.tags.filterOutput", required = true)
     private boolean filterFeaturesByTags;
 
-
     @Parameter(defaultValue = "false", property = "useTestNG", required = true)
     private boolean useTestNG;
 
@@ -140,6 +139,9 @@ public class GenerateRunnersMojo extends AbstractMojo implements FileGeneratorCo
      */
     @Parameter(defaultValue = "FEATURE", property = "parallelScheme", required = true)
     private ParallelScheme parallelScheme;
+
+    @Parameter(property = "customVmTemplate", required = false)
+    private String customVmTemplate;
 
     private CucumberITGenerator fileGenerator;
 
@@ -175,7 +177,6 @@ public class GenerateRunnersMojo extends AbstractMojo implements FileGeneratorCo
 
         return new CucumberITGeneratorFactory(this, overriddenParameters, classNamingScheme)
                         .create(parallelScheme);
-
     }
 
     private void createOutputDirIfRequired() {
@@ -197,7 +198,6 @@ public class GenerateRunnersMojo extends AbstractMojo implements FileGeneratorCo
         overriddenParameters.overrideParametersWithCucumberOptions(cucumberOptions);
 
         return overriddenParameters;
-
     }
 
     public boolean filterFeaturesByTags() {
@@ -228,5 +228,7 @@ public class GenerateRunnersMojo extends AbstractMojo implements FileGeneratorCo
         return namingPattern;
     }
 
-
+    public String getCustomVmTemplate() {
+        return customVmTemplate;
+    }
 }

--- a/src/test/java/com/github/timm/cucumber/generate/TestFileGeneratorConfig.java
+++ b/src/test/java/com/github/timm/cucumber/generate/TestFileGeneratorConfig.java
@@ -13,6 +13,7 @@ public class TestFileGeneratorConfig implements FileGeneratorConfig {
     private final boolean useTestNg = false;
     private final String namingScheme = "simple";
     private final String namingPattern = null;
+    private final String customVmTemplate = "";
 
     public TestFileGeneratorConfig setFeaturesDirectory(final File directory) {
         this.featuresDirectory = directory;
@@ -23,7 +24,6 @@ public class TestFileGeneratorConfig implements FileGeneratorConfig {
         this.outputDir = "target/" + classUnderTest.getSimpleName();
         return this;
     }
-
 
     public boolean filterFeaturesByTags() {
         return filterFeatureByTags;
@@ -55,6 +55,10 @@ public class TestFileGeneratorConfig implements FileGeneratorConfig {
 
     public String getNamingPattern() {
         return namingPattern;
+    }
+
+    public String getCustomVmTemplate() {
+        return customVmTemplate;
     }
 
     public TestFileGeneratorConfig setFilterFeaturesByTags(final boolean newValue) {


### PR DESCRIPTION
For discussion please see #61.

Usage would be something like:
```xml
...
<plugin>
  <groupId>com.github.temyers</groupId>
  <artifactId>cucumber-jvm-parallel-plugin</artifactId>
  <version>2.0.3</version>
  <executions>
    <execution>
      ...
      <configuration>
        ...
        <!-- custom template -->
        <customVmTemplate>src/test/resources/cucumber-custom-runner.vm</customVmTemplate>
      </configuration>
    </execution>
  </executions>
</plugin>
...
```