### PR TITLE
Inconsistent filters issue76

### DIFF
--- a/src/it/junit/issue_76-InconsistentFilters/pom.xml
+++ b/src/it/junit/issue_76-InconsistentFilters/pom.xml
@@ -1,0 +1,54 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>com.github.temyers.it</groupId>
+    <artifactId>simple-it</artifactId>
+    <version>1.0-SNAPSHOT</version>
+
+    <description>A simple IT verifying the basic use case.</description>
+
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <cucumber.version>1.2.2</cucumber.version>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>info.cukes</groupId>
+            <artifactId>cucumber-junit</artifactId>
+            <version>${cucumber.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>info.cukes</groupId>
+            <artifactId>cucumber-java</artifactId>
+            <version>${cucumber.version}</version>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>@project.groupId@</groupId>
+                <artifactId>@project.artifactId@</artifactId>
+                <version>@project.version@</version>
+                <executions>
+                    <execution>
+                        <id>generateRunners</id>
+                        <phase>generate-test-sources</phase>
+                        <goals>
+                            <goal>generateRunners</goal>
+                        </goals>
+                        <configuration>
+                            <glue>foo, bar</glue>
+                            <tags>"@complete,@accepted"</tags>
+                            <parallelScheme>SCENARIO</parallelScheme>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/src/it/junit/issue_76-InconsistentFilters/src/test/resources/features/feature1.feature
+++ b/src/it/junit/issue_76-InconsistentFilters/src/test/resources/features/feature1.feature
@@ -1,0 +1,15 @@
+Feature: Feature1
+
+  @complete
+  Scenario: Generate Junit Runner for each feature file
+    Given I have feature files
+    When I generate Maven sources
+    Then the file "target/generated-test-sources/1IT.java" should exist
+    And it should contain:
+    """
+    @RunWith(Cucumber.class)
+    @CucumberOptions(strict = true, features = {"classpath:features/feature1.feature:4"}, format = {"json:target/cucumber-parallel/1.json",
+    "pretty"}, monochrome = false, glue = { "foo", "bar" })
+    public class Parallel01IT {
+    }
+    """

--- a/src/it/junit/issue_76-InconsistentFilters/src/test/resources/features/feature2.feature
+++ b/src/it/junit/issue_76-InconsistentFilters/src/test/resources/features/feature2.feature
@@ -1,0 +1,15 @@
+Feature: Feature1
+
+  @accepted
+  Scenario: Generate Junit Runner for each feature file
+    Given I have feature files
+    When I generate Maven sources
+    Then the file "target/generated-test-sources/1IT.java" should exist
+    And it should contain:
+    """
+    @RunWith(Cucumber.class)
+    @CucumberOptions(strict = true, features = {"classpath:features/feature2.feature:4"}, format = {"json:target/cucumber-parallel/2.json",
+    "pretty"}, monochrome = false, glue = { "foo", "bar" })
+    public class Parallel02IT {
+    }
+    """

--- a/src/it/junit/issue_76-InconsistentFilters/verify.groovy
+++ b/src/it/junit/issue_76-InconsistentFilters/verify.groovy
@@ -1,0 +1,47 @@
+import org.junit.Assert
+
+import static org.hamcrest.Matchers.equalToIgnoringWhiteSpace
+
+File suite01 = new File(basedir, "target/generated-test-sources/cucumber/Parallel01IT.java");
+File suite02 = new File(basedir, "target/generated-test-sources/cucumber/Parallel02IT.java");
+
+File feature1 = new File(basedir, "/src/test/resources/features/feature1.feature");
+File feature2 = new File(basedir, "/src/test/resources/features/feature2.feature");
+
+assert suite01.isFile()
+assert suite02.isFile()
+
+String expected01 =
+        """import org.junit.runner.RunWith;
+
+import cucumber.api.CucumberOptions;
+import cucumber.api.junit.Cucumber;
+
+@RunWith(Cucumber.class)
+@CucumberOptions(strict = true, features = {"${feature1.absolutePath}:4"}, plugin = {"json:target/cucumber-parallel/1.json"},
+monochrome = false, glue = { "foo", "bar" })
+public class Parallel01IT {
+}"""
+
+String expected02 =
+        """import org.junit.runner.RunWith;
+
+import cucumber.api.CucumberOptions;
+import cucumber.api.junit.Cucumber;
+
+@RunWith(Cucumber.class)
+@CucumberOptions(strict = true, features = {"${feature2.absolutePath}:4"}, plugin = {"json:target/cucumber-parallel/2.json"},
+monochrome = false, glue = { "foo", "bar" })
+public class Parallel02IT {
+}"""
+
+// Depending on the OS, listFiles can list files in different order.  The actual order of files isn't necessary
+
+if (suite01.text.contains("feature1")) {
+    Assert.assertThat(suite01.text, equalToIgnoringWhiteSpace(expected01))
+    Assert.assertThat(suite02.text, equalToIgnoringWhiteSpace(expected02))
+} else {
+    Assert.assertThat(suite02.text, equalToIgnoringWhiteSpace(expected01))
+    Assert.assertThat(suite01.text, equalToIgnoringWhiteSpace(expected02))
+}
+

--- a/src/it/testng/issue_76-InconsistentFilters/pom.xml
+++ b/src/it/testng/issue_76-InconsistentFilters/pom.xml
@@ -1,0 +1,55 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>com.github.temyers.it</groupId>
+    <artifactId>simple-it</artifactId>
+    <version>1.0-SNAPSHOT</version>
+
+    <description>A simple IT verifying the basic use case.</description>
+
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <cucumber.version>1.2.2</cucumber.version>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>info.cukes</groupId>
+            <artifactId>cucumber-testng</artifactId>
+            <version>${cucumber.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>info.cukes</groupId>
+            <artifactId>cucumber-java</artifactId>
+            <version>${cucumber.version}</version>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>@project.groupId@</groupId>
+                <artifactId>@project.artifactId@</artifactId>
+                <version>@project.version@</version>
+                <executions>
+                    <execution>
+                        <id>generateRunners</id>
+                        <phase>generate-test-sources</phase>
+                        <goals>
+                            <goal>generateRunners</goal>
+                        </goals>
+                        <configuration>
+                            <glue>foo, bar</glue>
+                            <tags>"@complete,@accepted"</tags>
+                            <useTestNG>true</useTestNG>
+                            <parallelScheme>SCENARIO</parallelScheme>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/src/it/testng/issue_76-InconsistentFilters/src/test/resources/features/feature1.feature
+++ b/src/it/testng/issue_76-InconsistentFilters/src/test/resources/features/feature1.feature
@@ -1,0 +1,14 @@
+Feature: Feature1
+
+  @complete
+  Scenario: Generate TestNG Runner for each feature file
+    Given I have feature files
+    When I generate Maven sources
+    Then the file "target/generated-test-sources/1IT.java" should exist
+    And it should contain:
+    """
+    @CucumberOptions(strict = true, features = {"classpath:features/feature1.feature:4"}, format = {"json:target/cucumber-parallel/1.json",
+    "pretty"}, monochrome = false, glue = { "foo", "bar" })
+    public class Parallel01IT extends AbstractTestNGCucumberTests {
+    }
+    """

--- a/src/it/testng/issue_76-InconsistentFilters/src/test/resources/features/feature2.feature
+++ b/src/it/testng/issue_76-InconsistentFilters/src/test/resources/features/feature2.feature
@@ -1,0 +1,14 @@
+Feature: Feature1
+
+  @accepted
+  Scenario: Generate TestNG Runner for each feature file
+    Given I have feature files
+    When I generate Maven sources
+    Then the file "target/generated-test-sources/1IT.java" should exist
+    And it should contain:
+    """
+    @CucumberOptions(strict = true, features = {"classpath:features/feature1.feature"}, format = {"json:target/cucumber-parallel/1.json",
+    "pretty"}, monochrome = false,, glue = { "foo", "bar" })
+    public class Parallel01IT extends AbstractTestNGCucumberTests {
+    }
+    """

--- a/src/it/testng/issue_76-InconsistentFilters/verify.groovy
+++ b/src/it/testng/issue_76-InconsistentFilters/verify.groovy
@@ -1,0 +1,41 @@
+import org.junit.Assert
+
+import static org.hamcrest.Matchers.equalToIgnoringWhiteSpace
+
+File suite01 = new File(basedir, "target/generated-test-sources/cucumber/Parallel01IT.java");
+File suite02 = new File(basedir, "target/generated-test-sources/cucumber/Parallel02IT.java");
+
+File feature1 = new File(basedir, "/src/test/resources/features/feature1.feature");
+File feature2 = new File(basedir, "/src/test/resources/features/feature2.feature");
+
+assert suite01.isFile()
+assert suite02.isFile()
+
+String expected01 =
+        """import cucumber.api.CucumberOptions;
+import cucumber.api.testng.AbstractTestNGCucumberTests;
+
+@CucumberOptions(strict = true, features = {"${feature1.absolutePath}:4"}, plugin = {"json:target/cucumber-parallel/1.json"},
+monochrome = false, glue = { "foo", "bar" })
+public class Parallel01IT extends AbstractTestNGCucumberTests {
+}"""
+
+String expected02 =
+        """import cucumber.api.CucumberOptions;
+import cucumber.api.testng.AbstractTestNGCucumberTests;
+
+@CucumberOptions(strict = true, features = {"${feature2.absolutePath}:4"}, plugin = {"json:target/cucumber-parallel/2.json"},
+monochrome = false, glue = { "foo", "bar" })
+public class Parallel02IT extends AbstractTestNGCucumberTests {
+}"""
+
+// Depending on the OS, listFiles can list files in different order.  The actual order of files isn't necessary
+
+if (suite01.text.contains("feature1")) {
+    Assert.assertThat(suite01.text, equalToIgnoringWhiteSpace(expected01))
+    Assert.assertThat(suite02.text, equalToIgnoringWhiteSpace(expected02))
+} else {
+    Assert.assertThat(suite02.text, equalToIgnoringWhiteSpace(expected01))
+    Assert.assertThat(suite01.text, equalToIgnoringWhiteSpace(expected02))
+}
+

--- a/src/main/resources/cucumber-junit-runner.vm
+++ b/src/main/resources/cucumber-junit-runner.vm
@@ -8,7 +8,7 @@ import cucumber.api.junit.Cucumber;
 features = {"$featureFile"},
 plugin = {$reports},
 monochrome = ${monochrome},
-tags = {#if($tags)$tags#end},
+#if(!$featureFile.contains(".feature:") ) tags = {$tags},#end
 glue = { $glue })
 public class $className {
 }

--- a/src/main/resources/cucumber-junit-runner.vm
+++ b/src/main/resources/cucumber-junit-runner.vm
@@ -9,6 +9,6 @@ features = {"$featureFile"},
 plugin = {$reports},
 monochrome = ${monochrome},
 #if(!$featureFile.contains(".feature:") ) tags = {$tags},#end
-glue = { $glue })
+ glue = { $glue })
 public class $className {
 }

--- a/src/main/resources/cucumber-junit-runner.vm
+++ b/src/main/resources/cucumber-junit-runner.vm
@@ -8,7 +8,7 @@ import cucumber.api.junit.Cucumber;
 features = {"$featureFile"},
 plugin = {$reports},
 monochrome = ${monochrome},
-#if(!$featureFile.contains(".feature:") ) tags = {#if($tags)$tags#end},#end
- glue = { $glue })
+#if(!$featureFile.contains(".feature:") ) tags = {#if($tags)$tags#end}, #end
+glue = { $glue })
 public class $className {
 }

--- a/src/main/resources/cucumber-junit-runner.vm
+++ b/src/main/resources/cucumber-junit-runner.vm
@@ -8,7 +8,7 @@ import cucumber.api.junit.Cucumber;
 features = {"$featureFile"},
 plugin = {$reports},
 monochrome = ${monochrome},
-#if(!$featureFile.contains(".feature:") ) tags = {$tags},#end
+#if(!$featureFile.contains(".feature:") ) tags = {#if($tags)$tags#end},#end
  glue = { $glue })
 public class $className {
 }

--- a/src/main/resources/cucumber-testng-runner.vm
+++ b/src/main/resources/cucumber-testng-runner.vm
@@ -5,7 +5,7 @@ import cucumber.api.testng.AbstractTestNGCucumberTests;
 features = {"$featureFile"},
 plugin = {$reports},
 monochrome = ${monochrome},
-#if(!$featureFile.contains(".feature:") ) tags = {#if($tags)$tags#end},#end
- glue = { $glue })
+#if(!$featureFile.contains(".feature:") ) tags = {#if($tags)$tags#end}, #end
+glue = { $glue })
 public class $className extends AbstractTestNGCucumberTests {
 }

--- a/src/main/resources/cucumber-testng-runner.vm
+++ b/src/main/resources/cucumber-testng-runner.vm
@@ -5,7 +5,7 @@ import cucumber.api.testng.AbstractTestNGCucumberTests;
 features = {"$featureFile"},
 plugin = {$reports},
 monochrome = ${monochrome},
-#if(!$featureFile.contains(".feature:") ) tags = {$tags},#end
+#if(!$featureFile.contains(".feature:") ) tags = {#if($tags)$tags#end},#end
  glue = { $glue })
 public class $className extends AbstractTestNGCucumberTests {
 }

--- a/src/main/resources/cucumber-testng-runner.vm
+++ b/src/main/resources/cucumber-testng-runner.vm
@@ -5,7 +5,7 @@ import cucumber.api.testng.AbstractTestNGCucumberTests;
 features = {"$featureFile"},
 plugin = {$reports},
 monochrome = ${monochrome},
-tags = {#if($tags)$tags#end},
+#if(!$featureFile.contains(".feature:") ) tags = {$tags},#end
 glue = { $glue })
 public class $className extends AbstractTestNGCucumberTests {
 }

--- a/src/main/resources/cucumber-testng-runner.vm
+++ b/src/main/resources/cucumber-testng-runner.vm
@@ -6,6 +6,6 @@ features = {"$featureFile"},
 plugin = {$reports},
 monochrome = ${monochrome},
 #if(!$featureFile.contains(".feature:") ) tags = {$tags},#end
-glue = { $glue })
+ glue = { $glue })
 public class $className extends AbstractTestNGCucumberTests {
 }


### PR DESCRIPTION
@temyers Fixed issue InconsistentFilters and also added IT's for jUnit and TestNG.

Only one line change in both vm.

`#if(!$featureFile.contains(".feature:") ) tags = {#if($tags)$tags#end},#end`

this is the only one solution i found without touching existing code base. simply we can put `#if(!$featureFile.contains(".feature:") ) tags = {$tags},#end`
but this will reproduce issue 50 i.e. if tags are empty that case runner will have tags = {$tags}.

