### PR TITLE
use the baseDir of the current project for velocity

### DIFF
--- a/src/main/java/com/github/timm/cucumber/generate/CucumberITGeneratorByFeature.java
+++ b/src/main/java/com/github/timm/cucumber/generate/CucumberITGeneratorByFeature.java
@@ -64,6 +64,7 @@ public class CucumberITGeneratorByFeature implements CucumberITGenerator {
         if (StringUtils.isNotBlank(config.getCustomVmTemplate())) {
             // Look for custom template on the classpath or as a relative file path
             props.put("resource.loader", "class, file");
+            props.put("file.resource.loader.path", config.getProjectBasedir().getAbsolutePath());
             name = config.getCustomVmTemplate();
         } else if (config.useTestNG()) {
             name = "cucumber-testng-runner.vm";

--- a/src/main/java/com/github/timm/cucumber/generate/CucumberITGeneratorByScenario.java
+++ b/src/main/java/com/github/timm/cucumber/generate/CucumberITGeneratorByScenario.java
@@ -63,6 +63,7 @@ public class CucumberITGeneratorByScenario implements CucumberITGenerator {
         if (StringUtils.isNotBlank(config.getCustomVmTemplate())) {
             // Look for custom template on the classpath or as a relative file path
             props.put("resource.loader", "class, file");
+            props.put("file.resource.loader.path", config.getProjectBasedir().getAbsolutePath());
             name = config.getCustomVmTemplate();
         } else if (config.useTestNG()) {
             name = "cucumber-testng-runner.vm";

--- a/src/main/java/com/github/timm/cucumber/generate/FileGeneratorConfig.java
+++ b/src/main/java/com/github/timm/cucumber/generate/FileGeneratorConfig.java
@@ -25,4 +25,6 @@ public interface FileGeneratorConfig {
     String getCustomVmTemplate();
 
     String getPackageName();
+
+    File getProjectBasedir();
 }

--- a/src/main/java/com/github/timm/cucumber/generate/GenerateRunnersMojo.java
+++ b/src/main/java/com/github/timm/cucumber/generate/GenerateRunnersMojo.java
@@ -246,4 +246,8 @@ public class GenerateRunnersMojo extends AbstractMojo implements FileGeneratorCo
     public String getPackageName() {
         return packageName;
     }
+
+    public File getProjectBasedir() {
+        return project.getBasedir();
+    }
 }

--- a/src/test/java/com/github/timm/cucumber/generate/TestFileGeneratorConfig.java
+++ b/src/test/java/com/github/timm/cucumber/generate/TestFileGeneratorConfig.java
@@ -69,4 +69,9 @@ public class TestFileGeneratorConfig implements FileGeneratorConfig {
     public String getPackageName() {
         return null;
     }
+
+    public File getProjectBasedir() {
+        return new File(".");
+    }
+
 }


### PR DESCRIPTION
By default velocity takes the current working directory as base path. This fails if you use a custom velocity template and have a build where the current working directory is not the same as the project build directory (for example in a multi-module maven build).

This patch sets the base path of velocity to the project basedir from maven. The relative paths are now always relative to the project directory and don't depend on the current working directory.