### PR TITLE
Add support for custom cucumber plugins

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -175,6 +175,13 @@ It is up to you to ensure that class names generated are valid and there are no 
 
 The `namingPattern` property is for the **class name** only.  Do not add the `.java` suffix.
 
+### Custom Templates ###
+
+Some reporting plugins, such as
+[Cucumber Extent Reporter](https://github.com/email2vimalraj/CucumberExtentReporter), require some 
+setup before a test is started. A template can be used to customize the integration tests. For a 
+sample see the [extents-report](src/it/junit/extents-report) integration test.
+
 
 FAQ
 ===

--- a/readme.md
+++ b/readme.md
@@ -38,8 +38,19 @@ Add the following to your POM file:
         <featuresDirectory>src/test/resources/features/</featuresDirectory>
         <!-- Directory where the cucumber report files shall be written  -->
         <cucumberOutputDir>target/cucumber-parallel</cucumberOutputDir>
-        <!-- Comma separated list of output formats. Only html, json and pretty are supported -->
-        <format>json</format>
+        <!-- List of cucumber plugins. When none are provided the json formatter is used. For more 
+             advanced usage see section about configuring cucumber plugins -->
+        <plugins>
+            <plugins>
+                <plugin>
+                    <name>json</name>
+                </plugin>
+                <plugin>
+                    <name>my.other.package.CustomHtmlFormatter</name>
+                    <extension>html</extension>
+                </plugin>
+            </plugins>
+        </plugins>
         <!-- CucumberOptions.strict property -->
         <strict>true</strict>
         <!-- CucumberOptions.monochrome property -->
@@ -88,7 +99,58 @@ The Java source is generated in `outputDirectory`, based on the naming scheme us
 
 Each runner is configured to output the results to a separate output file under `target/cucumber-parallel`
 
-###Naming Scheme
+### Cucumber Plugins ###
+
+Cucumber plugins that write to a file are referenced using the syntax 
+`name[:outputDirectory/excutorId[.extension]]`. Because not all plugins create output and the 
+excutorId is provided at runtime some leg work is needed.
+
+#### Build-in Cucumber Plugins ####
+
+```xml
+<plugins>
+    <plugin>
+        <!--The available options are junit, testng, html, pretty, json, usage and rerun -->
+        <name>json</name>
+        <!--Optional file extension. For build in cucumber plugins a sensible default is provided. -->
+        <extension>json</extension>
+        <!--Optional output directory. Overrides cucumberOutputDirectory. Usefull when different 
+            plugins create files with the same extension-->
+        <outputDirectory>${project.build.directory}/cucumber-parallel/json</outputDirectory>
+    </plugin>
+</plugins>
+```
+
+#### Custom Cucumber Plugins ####
+
+```xml
+<plugins>
+    <plugin>
+        <name>path.to.my.formaters.CustomHtmlFormatter</name>
+        <!--Optional file extension. Unless the formatter writes to a file it is strongly 
+            recommend that one is provided. -->
+        <extension>html</extension>
+        <!--Optional output directory. Overrides cucumberOutputDirectory. Useful when different 
+            plugins create files with the same extension-->
+        <outputDirectory>${project.build.directory}/cucumber-parallel/html</outputDirectory>
+    </plugin>
+</plugins>
+```
+
+#### Custom Cucumber Plugins without output ####
+
+```xml
+<plugins>
+    <plugin>
+        <name>path.to.my.formaters.NoOutputFormatter</name>
+        <!--Set to true if this plug creates no output. Setting extension or outputDirectory 
+            will override this setting -->
+        <noOutput>true</noOutput>
+    </plugin>
+</plugins>
+```
+
+### Naming Scheme ###
 
 The naming scheme used for the generated files is controlled by the `namingScheme` property.  The following values are supported:
 
@@ -106,7 +168,7 @@ The following tokens can be used in the pattern:
 
 By default, generated test files use the `simple` naming strategy.
 
-####Note on Pattern Naming Scheme
+#### Note on Pattern Naming Scheme ####
 The `pattern` naming scheme is for advanced usage only.  
 
 It is up to you to ensure that class names generated are valid and there are no clashes.  If the same class name is generated multiple times, then it shall be overwritten and some of your tests will not be executed.

--- a/src/it/junit/all-build-in-plugins/pom.xml
+++ b/src/it/junit/all-build-in-plugins/pom.xml
@@ -1,0 +1,97 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>com.github.temyers.it</groupId>
+    <artifactId>simple-it</artifactId>
+    <version>1.0-SNAPSHOT</version>
+
+    <description>Output test report in multiple formats</description>
+
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <cucumber.version>1.2.2</cucumber.version>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>info.cukes</groupId>
+            <artifactId>cucumber-junit</artifactId>
+            <version>${cucumber.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>info.cukes</groupId>
+            <artifactId>cucumber-java</artifactId>
+            <version>${cucumber.version}</version>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>@project.groupId@</groupId>
+                <artifactId>@project.artifactId@</artifactId>
+                <version>@project.version@</version>
+                <executions>
+                    <execution>
+                        <id>generateRunners</id>
+                        <phase>generate-test-sources</phase>
+                        <goals>
+                            <goal>generateRunners</goal>
+                        </goals>
+                    </execution>
+                </executions>
+                <configuration>
+                    <glue>
+                        <package>foo</package>
+                    </glue>
+                    <plugins>
+                        <plugin>
+                            <name>null</name>
+                        </plugin>
+                        <plugin>
+                            <name>junit</name>
+                            <outputDirectory>${project.build.directory}/cucumber-parallel/junit</outputDirectory>
+                        </plugin>
+                        <plugin>
+                            <name>testng</name>
+                            <outputDirectory>${project.build.directory}/cucumber-parallel/testng</outputDirectory>
+                        </plugin>
+                        <plugin>
+                            <name>html</name>
+                            <outputDirectory>${project.build.directory}/cucumber-parallel/html</outputDirectory>
+                        </plugin>
+                        <plugin>
+                            <name>pretty</name>
+                        </plugin>
+                        <plugin>
+                            <name>progress</name>
+                            <outputDirectory>${project.build.directory}/cucumber-parallel/progress</outputDirectory>
+                        </plugin>
+                        <plugin>
+                            <name>json</name>
+                            <outputDirectory>${project.build.directory}/cucumber-parallel/json</outputDirectory>
+                        </plugin>
+                        <plugin>
+                            <name>usage</name>
+                            <outputDirectory>${project.build.directory}/cucumber-parallel/usage</outputDirectory>
+                        </plugin>
+                        <plugin>
+                            <name>rerun</name>
+                            <outputDirectory>${project.build.directory}/cucumber-parallel/rerun</outputDirectory>
+                        </plugin>
+                        <plugin>
+                            <name>default_summary</name>
+                            <outputDirectory>${project.build.directory}/cucumber-parallel/default_summary</outputDirectory>
+                        </plugin>
+                        <plugin>
+                            <name>null_summary</name>
+                        </plugin>
+                    </plugins>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/src/it/junit/all-build-in-plugins/src/test/resources/features/feature1.feature
+++ b/src/it/junit/all-build-in-plugins/src/test/resources/features/feature1.feature
@@ -1,0 +1,20 @@
+Feature: Feature1
+
+  Scenario: Generate Junit Runner for each feature file
+    Given I have feature files
+    When I generate Maven sources
+    Then the file "target/generated-test-sources/1IT.java" should exist
+    And it should contain:
+    """
+    @RunWith(Cucumber.class)
+    @CucumberOptions(
+        strict = true,
+        features = {"classpath:features/feature1.feature"},
+        format = {"json:target/cucumber-parallel/1.json",
+    "pretty"},
+        monochrome = false,
+        tags = {"@complete", "@accepted"},
+        glue = {"foo", "bar"})
+    public class Parallel01IT {
+    }
+    """

--- a/src/it/junit/all-build-in-plugins/verify.groovy
+++ b/src/it/junit/all-build-in-plugins/verify.groovy
@@ -1,0 +1,29 @@
+import org.junit.Assert
+
+import static org.hamcrest.Matchers.equalToIgnoringWhiteSpace
+
+File buildDirectory = new File(basedir, "target");
+File suite01 = new File(basedir, "target/generated-test-sources/cucumber/Parallel01IT.java");
+File feature1 = new File(basedir, "/src/test/resources/features/feature1.feature");
+
+assert suite01.isFile()
+
+String expected01 =
+        """import org.junit.runner.RunWith;
+
+import cucumber.api.CucumberOptions;
+import cucumber.api.junit.Cucumber;
+
+@RunWith(Cucumber.class)
+@CucumberOptions(
+        strict = true,
+        features = {"${feature1.absolutePath}"},
+        plugin = {"null", "junit:${buildDirectory.absolutePath}/cucumber-parallel/junit/1.xml", "testng:${buildDirectory.absolutePath}/cucumber-parallel/testng/1.xml", "html:${buildDirectory.absolutePath}/cucumber-parallel/html/1", "pretty", "progress:${buildDirectory.absolutePath}/cucumber-parallel/progress/1.txt", "json:${buildDirectory.absolutePath}/cucumber-parallel/json/1.json", "usage:${buildDirectory.absolutePath}/cucumber-parallel/usage/1.json", "rerun:${buildDirectory.absolutePath}/cucumber-parallel/rerun/1.txt", "default_summary", "null_summary"},
+        monochrome = false,
+        tags = {},
+        glue = {"foo"})
+public class Parallel01IT {
+}"""
+
+Assert.assertThat(suite01.text, equalToIgnoringWhiteSpace(expected01))
+  

--- a/src/it/junit/build-in-plugins-use-defaults/pom.xml
+++ b/src/it/junit/build-in-plugins-use-defaults/pom.xml
@@ -1,0 +1,65 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>com.github.temyers.it</groupId>
+    <artifactId>simple-it</artifactId>
+    <version>1.0-SNAPSHOT</version>
+
+    <description>Output test report in multiple formats</description>
+
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <cucumber.version>1.2.2</cucumber.version>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>info.cukes</groupId>
+            <artifactId>cucumber-junit</artifactId>
+            <version>${cucumber.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>info.cukes</groupId>
+            <artifactId>cucumber-java</artifactId>
+            <version>${cucumber.version}</version>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>@project.groupId@</groupId>
+                <artifactId>@project.artifactId@</artifactId>
+                <version>@project.version@</version>
+                <executions>
+                    <execution>
+                        <id>generateRunners</id>
+                        <phase>generate-test-sources</phase>
+                        <goals>
+                            <goal>generateRunners</goal>
+                        </goals>
+                    </execution>
+                </executions>
+                <configuration>
+                    <glue>
+                        <package>foo</package>
+                    </glue>
+                    <plugins>
+                        <plugin>
+                            <name>pretty</name>
+                        </plugin>
+                        <plugin>
+                            <name>html</name>
+                        </plugin>
+                        <plugin>
+                            <name>json</name>
+                        </plugin>
+                    </plugins>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/src/it/junit/build-in-plugins-use-defaults/src/test/resources/features/feature1.feature
+++ b/src/it/junit/build-in-plugins-use-defaults/src/test/resources/features/feature1.feature
@@ -1,0 +1,20 @@
+Feature: Feature1
+
+  Scenario: Generate Junit Runner for each feature file
+    Given I have feature files
+    When I generate Maven sources
+    Then the file "target/generated-test-sources/1IT.java" should exist
+    And it should contain:
+    """
+    @RunWith(Cucumber.class)
+    @CucumberOptions(
+        strict = true,
+        features = {"classpath:features/feature1.feature"},
+        format = {"json:target/cucumber-parallel/1.json",
+    "pretty"},
+        monochrome = false,
+        tags = {"@complete", "@accepted"},
+        glue = {"foo", "bar"})
+    public class Parallel01IT {
+    }
+    """

--- a/src/it/junit/build-in-plugins-use-defaults/verify.groovy
+++ b/src/it/junit/build-in-plugins-use-defaults/verify.groovy
@@ -1,0 +1,30 @@
+import org.junit.Assert
+
+import static org.hamcrest.Matchers.equalToIgnoringWhiteSpace
+
+File buildDirectory = new File(basedir, "target");
+File suite01 = new File(basedir, "target/generated-test-sources/cucumber/Parallel01IT.java");
+File feature1 = new File(basedir, "/src/test/resources/features/feature1.feature");
+
+assert suite01.isFile()
+
+String expected01 =
+        """import org.junit.runner.RunWith;
+
+import cucumber.api.CucumberOptions;
+import cucumber.api.junit.Cucumber;
+
+@RunWith(Cucumber.class)
+@CucumberOptions(
+        strict = true,
+        features = {"${feature1.absolutePath}"},
+        plugin = {"pretty", "html:${buildDirectory.absolutePath}/cucumber-parallel/1", "json:${buildDirectory.absolutePath}/cucumber-parallel/1.json"},
+        monochrome = false,
+        tags = {},
+        glue = {"foo"})
+public class Parallel01IT {
+}"""
+
+
+Assert.assertThat(suite01.text, equalToIgnoringWhiteSpace(expected01))
+  

--- a/src/it/junit/custom-plugin-no-output/pom.xml
+++ b/src/it/junit/custom-plugin-no-output/pom.xml
@@ -1,0 +1,60 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>com.github.temyers.it</groupId>
+    <artifactId>simple-it</artifactId>
+    <version>1.0-SNAPSHOT</version>
+
+    <description>Output test report in multiple formats</description>
+
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <cucumber.version>1.2.2</cucumber.version>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>info.cukes</groupId>
+            <artifactId>cucumber-junit</artifactId>
+            <version>${cucumber.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>info.cukes</groupId>
+            <artifactId>cucumber-java</artifactId>
+            <version>${cucumber.version}</version>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>@project.groupId@</groupId>
+                <artifactId>@project.artifactId@</artifactId>
+                <version>@project.version@</version>
+                <executions>
+                    <execution>
+                        <id>generateRunners</id>
+                        <phase>generate-test-sources</phase>
+                        <goals>
+                            <goal>generateRunners</goal>
+                        </goals>
+                    </execution>
+                </executions>
+                <configuration>
+                    <glue>
+                        <package>path.to.my.formaters</package>
+                    </glue>
+                    <plugins>
+                        <plugin>
+                            <name>path.to.my.formaters.NoOutputFormatter</name>
+                            <noOutput>true</noOutput>
+                        </plugin>
+                    </plugins>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/src/it/junit/custom-plugin-no-output/src/test/resources/features/feature1.feature
+++ b/src/it/junit/custom-plugin-no-output/src/test/resources/features/feature1.feature
@@ -1,0 +1,20 @@
+Feature: Feature1
+
+  Scenario: Generate Junit Runner for each feature file
+    Given I have feature files
+    When I generate Maven sources
+    Then the file "target/generated-test-sources/1IT.java" should exist
+    And it should contain:
+    """
+    @RunWith(Cucumber.class)
+    @CucumberOptions(
+        strict = true,
+        features = {"classpath:features/feature1.feature"},
+        format = {"json:target/cucumber-parallel/1.json",
+    "pretty"},
+        monochrome = false,
+        tags = {"@complete", "@accepted"},
+        glue = {"foo", "bar"})
+    public class Parallel01IT {
+    }
+    """

--- a/src/it/junit/custom-plugin-no-output/verify.groovy
+++ b/src/it/junit/custom-plugin-no-output/verify.groovy
@@ -1,0 +1,28 @@
+import org.junit.Assert
+
+import static org.hamcrest.Matchers.equalToIgnoringWhiteSpace
+
+File suite01 = new File(basedir, "target/generated-test-sources/cucumber/Parallel01IT.java");
+File feature1 = new File(basedir, "/src/test/resources/features/feature1.feature");
+
+assert suite01.isFile()
+
+String expected01 =
+        """import org.junit.runner.RunWith;
+
+import cucumber.api.CucumberOptions;
+import cucumber.api.junit.Cucumber;
+
+@RunWith(Cucumber.class)
+@CucumberOptions(
+        strict = true,
+        features = {"${feature1.absolutePath}"},
+        plugin = {"path.to.my.formaters.NoOutputFormatter"},
+        monochrome = false,
+        tags = {},
+        glue = {"path.to.my.formaters"})
+public class Parallel01IT {
+}"""
+
+Assert.assertThat(suite01.text, equalToIgnoringWhiteSpace(expected01))
+  

--- a/src/it/junit/custom-plugins/pom.xml
+++ b/src/it/junit/custom-plugins/pom.xml
@@ -1,0 +1,64 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>com.github.temyers.it</groupId>
+    <artifactId>simple-it</artifactId>
+    <version>1.0-SNAPSHOT</version>
+
+    <description>Output test report in multiple formats</description>
+
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <cucumber.version>1.2.2</cucumber.version>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>info.cukes</groupId>
+            <artifactId>cucumber-junit</artifactId>
+            <version>${cucumber.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>info.cukes</groupId>
+            <artifactId>cucumber-java</artifactId>
+            <version>${cucumber.version}</version>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>@project.groupId@</groupId>
+                <artifactId>@project.artifactId@</artifactId>
+                <version>@project.version@</version>
+                <executions>
+                    <execution>
+                        <id>generateRunners</id>
+                        <phase>generate-test-sources</phase>
+                        <goals>
+                            <goal>generateRunners</goal>
+                        </goals>
+                    </execution>
+                </executions>
+                <configuration>
+                    <glue>
+                        <package>path.to.my.formaters</package>
+                    </glue>
+                    <plugins>
+                        <plugin>
+                            <name>path.to.my.formaters.CustomHtmlFormatter</name>
+                            <extension>html</extension>
+                        </plugin>
+                        <plugin>
+                            <name>path.to.my.formaters.CustomJsonFormatter</name>
+                            <extension>json</extension>
+                        </plugin>
+                    </plugins>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/src/it/junit/custom-plugins/src/test/resources/features/feature1.feature
+++ b/src/it/junit/custom-plugins/src/test/resources/features/feature1.feature
@@ -1,0 +1,20 @@
+Feature: Feature1
+
+  Scenario: Generate Junit Runner for each feature file
+    Given I have feature files
+    When I generate Maven sources
+    Then the file "target/generated-test-sources/1IT.java" should exist
+    And it should contain:
+    """
+    @RunWith(Cucumber.class)
+    @CucumberOptions(
+        strict = true,
+        features = {"classpath:features/feature1.feature"},
+        format = {"json:target/cucumber-parallel/1.json",
+    "pretty"},
+        monochrome = false,
+        tags = {"@complete", "@accepted"},
+        glue = {"foo", "bar"})
+    public class Parallel01IT {
+    }
+    """

--- a/src/it/junit/custom-plugins/verify.groovy
+++ b/src/it/junit/custom-plugins/verify.groovy
@@ -1,0 +1,29 @@
+import org.junit.Assert
+
+import static org.hamcrest.Matchers.equalToIgnoringWhiteSpace
+
+File buildDirectory = new File(basedir, "target");
+File suite01 = new File(basedir, "target/generated-test-sources/cucumber/Parallel01IT.java");
+File feature1 = new File(basedir, "/src/test/resources/features/feature1.feature");
+
+assert suite01.isFile()
+
+String expected01 =
+        """import org.junit.runner.RunWith;
+
+import cucumber.api.CucumberOptions;
+import cucumber.api.junit.Cucumber;
+
+@RunWith(Cucumber.class)
+@CucumberOptions(
+        strict = true,
+        features = {"${feature1.absolutePath}"},
+        plugin = {"path.to.my.formaters.CustomHtmlFormatter:${buildDirectory.absolutePath}/cucumber-parallel/1.html", "path.to.my.formaters.CustomJsonFormatter:${buildDirectory.absolutePath}/cucumber-parallel/1.json"},
+        monochrome = false,
+        tags = {},
+        glue = {"path.to.my.formaters"})
+public class Parallel01IT {
+}"""
+
+Assert.assertThat(suite01.text, equalToIgnoringWhiteSpace(expected01))
+  

--- a/src/it/junit/extents-report/pom.xml
+++ b/src/it/junit/extents-report/pom.xml
@@ -1,0 +1,75 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>com.github.temyers.it</groupId>
+    <artifactId>simple-it</artifactId>
+    <version>1.0-SNAPSHOT</version>
+
+    <description>A simple IT verifying the basic use case.</description>
+
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <cucumber.version>1.2.2</cucumber.version>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>info.cukes</groupId>
+            <artifactId>cucumber-junit</artifactId>
+            <version>${cucumber.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>info.cukes</groupId>
+            <artifactId>cucumber-java</artifactId>
+            <version>${cucumber.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>com.vimalselvam</groupId>
+            <artifactId>cucumber-extentsreport</artifactId>
+            <version>2.0.4</version>
+        </dependency>
+        <dependency>
+            <groupId>com.aventstack</groupId>
+            <artifactId>extentreports</artifactId>
+            <version>3.0.2</version>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>@project.groupId@</groupId>
+                <artifactId>@project.artifactId@</artifactId>
+                <version>@project.version@</version>
+                <executions>
+                    <execution>
+                        <id>generateRunners</id>
+                        <phase>generate-test-sources</phase>
+                        <goals>
+                            <goal>generateRunners</goal>
+                        </goals>
+                        <configuration>
+                            <glue>
+                                <package>foo</package>
+                                <package>bar</package>
+                            </glue>
+                            <plugins>
+                                <plugin>
+                                    <name>com.cucumber.listener.ExtentCucumberFormatter</name>
+                                    <extension>html</extension>
+                                </plugin>
+                            </plugins>
+                            <customVmTemplate>
+                                src/test/resources/cucumber-extents-report-runner.java.vm
+                            </customVmTemplate>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/src/it/junit/extents-report/src/test/resources/cucumber-extents-report-runner.java.vm
+++ b/src/it/junit/extents-report/src/test/resources/cucumber-extents-report-runner.java.vm
@@ -1,0 +1,40 @@
+#parse("/array.java.vm")
+#if ($packageName)
+package $packageName;
+
+#end
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.runner.RunWith;
+
+import cucumber.api.CucumberOptions;
+import cucumber.api.junit.Cucumber;
+import com.cucumber.listener.Reporter;
+
+import java.io.File;
+
+@RunWith(Cucumber.class)
+@CucumberOptions(
+        strict = $strict,
+        features = {"$featureFile"},
+        plugin = #stringArray($plugins),
+        monochrome = $monochrome,
+#if(!$featureFile.contains(".feature:") && $tags)
+        tags = #stringArray($tags),
+#end
+        glue = #stringArray($glue))
+public class $className {
+
+    @BeforeClass
+    public static void beforeClass(){
+      //Do things
+    }
+
+    @AfterClass
+    public static void afterClass(){
+      Reporter.loadXMLConfig(new File("src/test/resources/extent-config.xml"));
+      Reporter.setSystemInfo("user", System.getProperty("user.name"));
+      Reporter.setSystemInfo("os", "Mac OSX");
+      Reporter.setTestRunnerOutput("Sample test runner output message");
+    }
+}

--- a/src/it/junit/extents-report/src/test/resources/features/feature1.feature
+++ b/src/it/junit/extents-report/src/test/resources/features/feature1.feature
@@ -1,0 +1,20 @@
+Feature: Feature1
+
+  Scenario: Generate Junit Runner for each feature file
+    Given I have feature files
+    When I generate Maven sources
+    Then the file "target/generated-test-sources/1IT.java" should exist
+    And it should contain:
+    """
+    @RunWith(Cucumber.class)
+    @CucumberOptions(
+        strict = true,
+        features = {"classpath:features/feature1.feature"},
+        format = {"json:target/cucumber-parallel/1.json",
+    "pretty"},
+        monochrome = false,
+        tags = {"@complete", "@accepted"},
+        glue = {"foo", "bar"})
+    public class Parallel01IT {
+    }
+    """

--- a/src/it/junit/extents-report/src/test/resources/features/feature2.feature
+++ b/src/it/junit/extents-report/src/test/resources/features/feature2.feature
@@ -1,0 +1,19 @@
+Feature: Feature1
+
+  Scenario: Generate Junit Runner for each feature file
+    Given I have feature files
+    When I generate Maven sources
+    Then the file "target/generated-test-sources/1IT.java" should exist
+    And it should contain:
+    """
+    @RunWith(Cucumber.class)
+    @CucumberOptions(
+        strict = true,
+        features = {"classpath:features/feature2.feature"},
+        format = {"json:target/cucumber-parallel/2.json", "pretty"},
+        monochrome = false,
+        tags = {"@complete", "@accepted"},
+        glue = {"foo", "bar"})
+    public class Parallel02IT {
+    }
+    """

--- a/src/it/junit/extents-report/verify.groovy
+++ b/src/it/junit/extents-report/verify.groovy
@@ -1,0 +1,95 @@
+import org.junit.Assert
+
+import static org.hamcrest.Matchers.equalToIgnoringWhiteSpace
+
+File buildDirectory = new File(basedir, "target");
+
+File suite01 = new File(basedir, "target/generated-test-sources/cucumber/Parallel01IT.java");
+File suite02 = new File(basedir, "target/generated-test-sources/cucumber/Parallel02IT.java");
+
+File feature1 = new File(basedir, "/src/test/resources/features/feature1.feature");
+File feature2 = new File(basedir, "/src/test/resources/features/feature2.feature");
+
+assert suite01.isFile()
+assert suite02.isFile()
+
+String expected01 =
+        """import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.runner.RunWith;
+
+import cucumber.api.CucumberOptions;
+import cucumber.api.junit.Cucumber;
+import com.cucumber.listener.Reporter;
+
+import java.io.File;
+
+@RunWith(Cucumber.class)
+@CucumberOptions(
+        strict = true,
+        features = {"${feature1.absolutePath}"},
+        plugin = {"com.cucumber.listener.ExtentCucumberFormatter:${buildDirectory.absolutePath}/cucumber-parallel/1.html"},
+        monochrome = false,
+        tags = {},
+        glue = {"foo", "bar"})
+public class Parallel01IT {
+
+    @BeforeClass
+    public static void beforeClass(){
+      //Do things
+    }
+
+    @AfterClass
+    public static void afterClass(){
+      Reporter.loadXMLConfig(new File("src/test/resources/extent-config.xml"));
+      Reporter.setSystemInfo("user", System.getProperty("user.name"));
+      Reporter.setSystemInfo("os", "Mac OSX");
+      Reporter.setTestRunnerOutput("Sample test runner output message");
+    }
+}"""
+
+String expected02 =
+        """import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.runner.RunWith;
+
+import cucumber.api.CucumberOptions;
+import cucumber.api.junit.Cucumber;
+import com.cucumber.listener.Reporter;
+
+import java.io.File;
+
+@RunWith(Cucumber.class)
+@CucumberOptions(
+        strict = true,
+        features = {"${feature2.absolutePath}"},
+        plugin = {"com.cucumber.listener.ExtentCucumberFormatter:${buildDirectory.absolutePath}/cucumber-parallel/2.html"},
+        monochrome = false,
+        tags = {},
+        glue = {"foo", "bar"})
+public class Parallel02IT {
+
+    @BeforeClass
+    public static void beforeClass(){
+      //Do things
+    }
+
+    @AfterClass
+    public static void afterClass(){
+      Reporter.loadXMLConfig(new File("src/test/resources/extent-config.xml"));
+      Reporter.setSystemInfo("user", System.getProperty("user.name"));
+      Reporter.setSystemInfo("os", "Mac OSX");
+      Reporter.setTestRunnerOutput("Sample test runner output message");
+    }
+}"""
+
+// Depending on the OS, listFiles can list files in different order.  The actual order of files isn't necessary
+
+if (suite01.text.contains("feature1")) {
+    Assert.assertThat(suite01.text, equalToIgnoringWhiteSpace(expected01))
+    Assert.assertThat(suite02.text, equalToIgnoringWhiteSpace(expected02))
+} else {
+    Assert.assertThat(suite02.text, equalToIgnoringWhiteSpace(expected01))
+    Assert.assertThat(suite01.text, equalToIgnoringWhiteSpace(expected02))
+}
+

--- a/src/it/junit/multiple-format/verify.groovy
+++ b/src/it/junit/multiple-format/verify.groovy
@@ -23,7 +23,7 @@ import cucumber.api.junit.Cucumber;
 @CucumberOptions(
         strict = true,
         features = {"${feature1.absolutePath}"},
-        plugin = {"html:${buildDirectory.absolutePath}/cucumber-parallel/1.html", "json:${buildDirectory.absolutePath}/cucumber-parallel/1.json", "pretty"},
+        plugin = {"html:${buildDirectory.absolutePath}/cucumber-parallel/1", "json:${buildDirectory.absolutePath}/cucumber-parallel/1.json", "pretty"},
         monochrome = false,
         tags = {"@complete", "@accepted"},
         glue = {"foo"})
@@ -40,7 +40,7 @@ import cucumber.api.junit.Cucumber;
 @CucumberOptions(
         strict = true,
         features = {"${feature2.absolutePath}"},
-        plugin = {"html:${buildDirectory.absolutePath}/cucumber-parallel/2.html", "json:${buildDirectory.absolutePath}/cucumber-parallel/2.json", "pretty"},
+        plugin = {"html:${buildDirectory.absolutePath}/cucumber-parallel/2", "json:${buildDirectory.absolutePath}/cucumber-parallel/2.json", "pretty"},
         monochrome = false,
         tags = {"@complete", "@accepted"},
         glue = {"foo"})

--- a/src/it/testng/multiple-format/verify.groovy
+++ b/src/it/testng/multiple-format/verify.groovy
@@ -20,7 +20,7 @@ import cucumber.api.testng.AbstractTestNGCucumberTests;
 @CucumberOptions(
         strict = true,
         features = {"${feature1.absolutePath}"},
-        plugin = {"html:${buildDirectory.absolutePath}/cucumber-parallel/1.html", "json:${buildDirectory.absolutePath}/cucumber-parallel/1.json", "pretty"},
+        plugin = {"html:${buildDirectory.absolutePath}/cucumber-parallel/1", "json:${buildDirectory.absolutePath}/cucumber-parallel/1.json", "pretty"},
         monochrome = false,
         tags = {"@complete", "@accepted"},
         glue = {"foo"})
@@ -34,7 +34,7 @@ import cucumber.api.testng.AbstractTestNGCucumberTests;
 @CucumberOptions(
         strict = true,
         features = {"${feature2.absolutePath}"},
-        plugin = {"html:${buildDirectory.absolutePath}/cucumber-parallel/2.html", "json:${buildDirectory.absolutePath}/cucumber-parallel/2.json", "pretty"},
+        plugin = {"html:${buildDirectory.absolutePath}/cucumber-parallel/2", "json:${buildDirectory.absolutePath}/cucumber-parallel/2.json", "pretty"},
         monochrome = false,
         tags = {"@complete", "@accepted"},
         glue = {"foo"})

--- a/src/main/java/com/github/timm/cucumber/generate/CucumberITGeneratorByFeature.java
+++ b/src/main/java/com/github/timm/cucumber/generate/CucumberITGeneratorByFeature.java
@@ -194,18 +194,8 @@ public class CucumberITGeneratorByFeature implements CucumberITGenerator {
      */
     private List<String> createPluginStrings() {
         final List<String> formatList = new ArrayList<String>();
-        for (String plugin : overriddenParameters.getPlugins()) {
-            final String formatStr = plugin.trim();
-            if ("pretty".equalsIgnoreCase(formatStr)) {
-                formatList.add("pretty");
-            } else {
-                formatList.add(format("%s:%s/%s.%s",
-                        formatStr,
-                        normalizePathSeparator(config.getCucumberOutputDir()),
-                        fileCounter,
-                        formatStr));
-            }
-
+        for (Plugin plugin : overriddenParameters.getPlugins()) {
+            formatList.add(plugin.asPluginString(fileCounter));
         }
         return formatList;
     }

--- a/src/main/java/com/github/timm/cucumber/generate/CucumberITGeneratorByScenario.java
+++ b/src/main/java/com/github/timm/cucumber/generate/CucumberITGeneratorByScenario.java
@@ -183,18 +183,8 @@ public class CucumberITGeneratorByScenario implements CucumberITGenerator {
      */
     private List<String> createPluginStrings() {
         final List<String> formatList = new ArrayList<String>();
-        for (String plugin : overriddenParameters.getPlugins()) {
-            final String formatStr = plugin.trim();
-            if ("pretty".equalsIgnoreCase(formatStr)) {
-                formatList.add("pretty");
-            } else {
-                formatList.add(format("%s:%s/%s.%s",
-                        formatStr,
-                        normalizePathSeparator(config.getCucumberOutputDir()),
-                        fileCounter,
-                        formatStr));
-            }
-
+        for (Plugin plugin : overriddenParameters.getPlugins()) {
+            formatList.add(plugin.asPluginString(fileCounter));
         }
         return formatList;
     }

--- a/src/main/java/com/github/timm/cucumber/generate/FileGeneratorConfig.java
+++ b/src/main/java/com/github/timm/cucumber/generate/FileGeneratorConfig.java
@@ -10,17 +10,11 @@ public interface FileGeneratorConfig {
 
     Log getLog();
 
-    File getFeaturesDirectory();
-
     String getEncoding();
 
     File getCucumberOutputDir();
 
     boolean useTestNG();
-
-    String getNamingScheme();
-
-    String getNamingPattern();
 
     String getCustomVmTemplate();
 

--- a/src/main/java/com/github/timm/cucumber/generate/Plugin.java
+++ b/src/main/java/com/github/timm/cucumber/generate/Plugin.java
@@ -1,0 +1,156 @@
+package com.github.timm.cucumber.generate;
+
+import java.io.File;
+import java.util.HashMap;
+import java.util.Map;
+
+public class Plugin {
+
+    private static final Map<String, Plugin> BUILD_IN_PLUGINS = createBuildInPlugins();
+
+    private static Map<String, Plugin> createBuildInPlugins() {
+        Map<String, Plugin> plugins = new HashMap<String, Plugin>();
+        plugins.put("null", createPluginWithoutOutput("null"));
+        plugins.put("junit", new Plugin("junit", "xml"));
+        plugins.put("testng", new Plugin("testng", "xml"));
+        plugins.put("html", new Plugin("html", null));
+        plugins.put("pretty", createPluginWithoutOutput("pretty"));
+        plugins.put("progress", new Plugin("progress", "txt"));
+        plugins.put("json", new Plugin("json", "json"));
+        plugins.put("usage", new Plugin("usage", "json"));
+        plugins.put("rerun", new Plugin("rerun", "txt"));
+        plugins.put("default_summary", createPluginWithoutOutput("default_summary"));
+        plugins.put("null_summary", createPluginWithoutOutput("null_summary"));
+        return plugins;
+    }
+
+    private String name;
+
+    public boolean isNoOutput() {
+        return noOutput;
+    }
+
+    public void setNoOutput(boolean noOutput) {
+        this.noOutput = noOutput;
+    }
+
+    private boolean noOutput;
+    private String extension;
+    private File outputDirectory;
+
+    public Plugin() {
+    }
+
+    private Plugin(String name, String extension) {
+        this.name = name;
+        this.extension = extension;
+    }
+
+
+    private Plugin(String name, boolean noOutput) {
+        this.name = name;
+        this.noOutput = noOutput;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String getExtension() {
+        return extension;
+    }
+
+    public void setExtension(String extension) {
+        this.extension = extension;
+    }
+
+    public File getOutputDirectory() {
+        return outputDirectory;
+    }
+
+    public void setOutputDirectory(File outputDirectory) {
+        this.outputDirectory = outputDirectory;
+    }
+
+    void applyDefaults(File defaultOutputDirectory) {
+        if (BUILD_IN_PLUGINS.containsKey(name)) {
+            applyDefaultsForBuildinPlugins();
+        }
+
+        // disable noOutput when we have an output directory or extension
+        if (isNoOutput()) {
+            noOutput = outputDirectory == null && extension == null;
+        }
+
+        // Unless noOutput is specifically enabled we assume that this plugin creates output.
+        if (outputDirectory == null && !isNoOutput()) {
+            outputDirectory = defaultOutputDirectory;
+        }
+    }
+
+    private void applyDefaultsForBuildinPlugins() {
+        Plugin knownPlugin = BUILD_IN_PLUGINS.get(name);
+
+        // Unless extension is overridden we assume that this plugin uses the default.
+        if (extension == null) {
+            extension = knownPlugin.getExtension();
+        }
+
+        noOutput = knownPlugin.isNoOutput();
+        // Because this plugin is known we always override any user input
+        // about what the plugin outputs when it outputs nothing.
+        if (noOutput) {
+            extension = null;
+            outputDirectory = null;
+        }
+    }
+
+    static Plugin createPluginWithoutOutput(String pluginString) {
+        return new Plugin(pluginString, true);
+    }
+
+    static Plugin createBuildInPlugin(String name) {
+        Plugin plugin = BUILD_IN_PLUGINS.get(name);
+        if (plugin == null) {
+            throw new IllegalArgumentException(name + " is not a build in cucumber plugin");
+        }
+
+        return new Plugin(plugin.name, plugin.extension);
+    }
+
+    String asPluginString(int fileCounter) {
+
+        String formatStr = name;
+
+        if (outputDirectory == null) {
+            return formatStr;
+        }
+
+        formatStr += ":" + normalizePathSeparator(outputDirectory) + "/" + fileCounter;
+
+        if (extension == null) {
+            return formatStr;
+        }
+
+        return formatStr + "." + extension;
+    }
+
+    private static String normalizePathSeparator(File file) {
+        return file.getPath().replace(File.separatorChar, '/');
+    }
+
+    @Override
+    public String toString() {
+        return "Plugin{"
+            + "name='" + name + '\''
+            + ", noOutput=" + noOutput
+            + ", extension='" + extension + '\''
+            + ", outputDirectory=" + outputDirectory
+            + '}';
+    }
+
+}

--- a/src/main/java/com/github/timm/cucumber/options/RuntimeOptions.java
+++ b/src/main/java/com/github/timm/cucumber/options/RuntimeOptions.java
@@ -1,7 +1,6 @@
 package com.github.timm.cucumber.options;
 
 import java.util.ArrayList;
-import java.util.LinkedList;
 import java.util.List;
 
 
@@ -14,10 +13,10 @@ public class RuntimeOptions {
 
     private final List<String> glue = new ArrayList<String>();
     private final List<String> filters = new ArrayList<String>();
-    private final List<String> pluginNames = new LinkedList<String>();
-    private boolean dryRun;
-    private boolean strict = false;
-    private boolean monochrome = false;
+    private final List<String> pluginNames = new ArrayList<String>();
+    private Boolean dryRun = null;
+    private Boolean strict = null;
+    private Boolean monochrome = null;
 
     /**
      * Create a new instance from a string of options, for example:
@@ -89,19 +88,19 @@ public class RuntimeOptions {
         }
     }
 
-    private void addPluginName(final String plugin) {
-        pluginNames.add(plugin);
+    private void addPluginName(final String pluginString) {
+        pluginNames.add(pluginString);
     }
 
     public List<String> getGlue() {
         return glue;
     }
 
-    public boolean isStrict() {
+    public Boolean isStrict() {
         return strict;
     }
 
-    public boolean isDryRun() {
+    public Boolean isDryRun() {
         return dryRun;
     }
 
@@ -109,7 +108,7 @@ public class RuntimeOptions {
         return filters;
     }
 
-    public boolean isMonochrome() {
+    public Boolean isMonochrome() {
         return monochrome;
     }
 

--- a/src/test/java/com/github/timm/cucumber/generate/CucumberITGeneratorByFeatureTest.java
+++ b/src/test/java/com/github/timm/cucumber/generate/CucumberITGeneratorByFeatureTest.java
@@ -1,5 +1,6 @@
 package com.github.timm.cucumber.generate;
 
+import static com.github.timm.cucumber.generate.Plugin.createBuildInPlugin;
 import static java.util.Collections.singletonList;
 import static org.fest.assertions.Assertions.assertThat;
 
@@ -10,28 +11,27 @@ import org.junit.Before;
 import org.junit.Test;
 
 import java.io.File;
-import java.util.Arrays;
 import java.util.Collections;
 
 public class CucumberITGeneratorByFeatureTest {
 
-    CucumberITGeneratorByFeature classUnderTest;
-    private TestFileGeneratorConfig config;
+    @SuppressWarnings("deprecation")
+    private CucumberITGeneratorByFeature classUnderTest;
     private File outputDirectory;
 
     @Before
     public void setup() throws Exception {
-        config = new TestFileGeneratorConfig()
-                        .setFeaturesDirectory(
-                                        new File("src/test/resources/features/"))
-                        .setCucumberOutputDir(this.getClass());
+        TestFileGeneratorConfig config = new TestFileGeneratorConfig()
+            .setFeaturesDirectory(
+                new File("src/test/resources/features/"))
+            .setCucumberOutputDir(this.getClass());
 
         final OverriddenCucumberOptionsParameters overriddenParameters =
                 new OverriddenCucumberOptionsParameters()
                         .setTags(Collections.<String>emptyList())
                         .setGlue(singletonList("foo"))
                         .setStrict(true)
-                        .setPlugins(singletonList("json"))
+                        .setPlugins(singletonList(createBuildInPlugin("json")))
                         .setMonochrome(false);
 
         final ClassNamingScheme classNamingScheme =

--- a/src/test/java/com/github/timm/cucumber/generate/CucumberITGeneratorByScenarioTest.java
+++ b/src/test/java/com/github/timm/cucumber/generate/CucumberITGeneratorByScenarioTest.java
@@ -1,5 +1,6 @@
 package com.github.timm.cucumber.generate;
 
+import static com.github.timm.cucumber.generate.Plugin.createBuildInPlugin;
 import static java.util.Collections.singletonList;
 import static org.fest.assertions.Assertions.assertThat;
 
@@ -13,7 +14,6 @@ import org.junit.Test;
 
 import java.io.File;
 import java.io.IOException;
-import java.util.Arrays;
 import java.util.Collections;
 
 public class CucumberITGeneratorByScenarioTest {
@@ -34,7 +34,7 @@ public class CucumberITGeneratorByScenarioTest {
                         .setTags(Collections.<String>emptyList())
                         .setGlue(singletonList("foo"))
                         .setStrict(true)
-                        .setPlugins(singletonList("json"))
+                        .setPlugins(singletonList(createBuildInPlugin("json")))
                         .setMonochrome(false);
 
         final ClassNamingScheme classNamingScheme =

--- a/src/test/java/com/github/timm/cucumber/generate/CucumberITGeneratorFactoryTest.java
+++ b/src/test/java/com/github/timm/cucumber/generate/CucumberITGeneratorFactoryTest.java
@@ -1,5 +1,6 @@
 package com.github.timm.cucumber.generate;
 
+import static com.github.timm.cucumber.generate.Plugin.createBuildInPlugin;
 import static java.util.Collections.singletonList;
 import static org.fest.assertions.Assertions.assertThat;
 
@@ -26,7 +27,7 @@ public class CucumberITGeneratorFactoryTest {
                                 .setTags(Collections.<String>emptyList())
                                 .setGlue(singletonList("foo"))
                                 .setStrict(true)
-                                .setPlugins(singletonList("json"))
+                                .setPlugins(singletonList(createBuildInPlugin("json")))
                                 .setMonochrome(false);
 
         final ClassNamingScheme classNamingScheme =
@@ -36,6 +37,7 @@ public class CucumberITGeneratorFactoryTest {
     }
 
     @Test
+    @SuppressWarnings("deprecation")
     public void shouldCreateFeatureRunner() throws Exception {
         final CucumberITGenerator generator = factory.create(ParallelScheme.FEATURE);
         assertThat(generator).isInstanceOf(CucumberITGeneratorByFeature.class);

--- a/src/test/java/com/github/timm/cucumber/generate/OverriddenCucumberOptionsParametersShouldOverrideParametersWithCucumberOptionsTest.java
+++ b/src/test/java/com/github/timm/cucumber/generate/OverriddenCucumberOptionsParametersShouldOverrideParametersWithCucumberOptionsTest.java
@@ -3,10 +3,14 @@ package com.github.timm.cucumber.generate;
 import static java.util.Arrays.asList;
 import static java.util.Collections.singletonList;
 import static org.hamcrest.Matchers.equalTo;
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThat;
 
+import com.github.timm.cucumber.options.RuntimeOptions;
 import org.junit.Before;
 import org.junit.Test;
+
+import java.util.Collections;
 
 public class OverriddenCucumberOptionsParametersShouldOverrideParametersWithCucumberOptionsTest {
 
@@ -21,8 +25,7 @@ public class OverriddenCucumberOptionsParametersShouldOverrideParametersWithCucu
     public void tagsParameterIsOverridden() {
         params.setTags(singletonList("\"@replaceMe\""));
 
-        params.overrideParametersWithCucumberOptions("--tags @tag1 --tags @tag2");
-
+        params.overrideTags(new RuntimeOptions("--tags @tag1 --tags @tag2").getFilters());
         assertThat(params.getTags(), equalTo(asList("@tag1","@tag2")));
     }
 
@@ -30,7 +33,7 @@ public class OverriddenCucumberOptionsParametersShouldOverrideParametersWithCucu
     public void glueParameterIsOverridden() {
         params.setGlue(asList("a.b.c","d.e.f"));
 
-        params.overrideParametersWithCucumberOptions("--glue somewhere --glue somewhere.else");
+        params.overrideGlue(new RuntimeOptions("--glue somewhere --glue somewhere.else").getGlue());
         assertThat(params.getGlue(), equalTo(asList("somewhere","somewhere.else")));
     }
 
@@ -38,16 +41,23 @@ public class OverriddenCucumberOptionsParametersShouldOverrideParametersWithCucu
     public void strictParameterIsOverriddenIfSpecified() {
         params.setStrict(false);
 
-        params.overrideParametersWithCucumberOptions("--strict");
+        params.overrideStrict(new RuntimeOptions("--strict").isStrict());
         assertThat(params.isStrict(), equalTo(true));
+    }
 
+    @Test
+    public void strictParameterIsOverriddenIfSpecified2() {
+        params.setStrict(true);
+
+        params.overrideStrict(new RuntimeOptions("--no-strict").isStrict());
+        assertThat(params.isStrict(), equalTo(false));
     }
 
     @Test
     public void strictParameterIsMaintainedIfNotSpecified() {
         params.setStrict(true);
 
-        params.overrideParametersWithCucumberOptions("--glue somewhere,somewhere.else");
+        params.overrideStrict(new RuntimeOptions("--glue somewhere,somewhere.else").isStrict());
         assertThat(params.isStrict(), equalTo(true));
     }
 
@@ -55,24 +65,52 @@ public class OverriddenCucumberOptionsParametersShouldOverrideParametersWithCucu
     public void strictParameterIsMaintainedIfNotSpecified2() {
 
         params.setStrict(false);
-        params.overrideParametersWithCucumberOptions("--glue somewhere,somewhere.else");
+        params.overrideStrict(new RuntimeOptions("--glue somewhere,somewhere.else").isStrict());
         assertThat(params.isStrict(), equalTo(false));
     }
 
     @Test
     public void formatParameterIsOverridden() {
 
-        params.setPlugins(singletonList("somethingElse"));
-        params.overrideParametersWithCucumberOptions(
-                        "--format html --plugin pretty --glue somewhere");
-        assertThat(params.getPlugins(), equalTo(asList("html","pretty")));
+        params.setPlugins(singletonList(Plugin.createBuildInPlugin("html")));
+        params.overridePlugins(singletonList(Plugin.createBuildInPlugin("json")));
+        assertEquals("json", params.getPlugins().get(0).getName());
+    }
+
+    @Test
+    public void formatParameterIsMaintainedIfNotSpecified() {
+        params.setPlugins(singletonList(Plugin.createBuildInPlugin("html")));
+        params.overridePlugins(Collections.<Plugin>emptyList());
+        assertEquals("html", params.getPlugins().get(0).getName());
     }
 
     @Test
     public void monochromeParameterIsOverridden() {
 
         params.setMonochrome(false);
-        params.overrideParametersWithCucumberOptions("--monochrome");
+        params.overrideMonochrome(new RuntimeOptions("--monochrome").isMonochrome());
+        assertThat(params.isMonochrome(), equalTo(true));
+    }
+
+    @Test
+    public void monochromeParameterIsOverridden2() {
+        params.setMonochrome(true);
+        params.overrideMonochrome(new RuntimeOptions("--no-monochrome").isMonochrome());
+        assertThat(params.isMonochrome(), equalTo(false));
+    }
+
+
+    @Test
+    public void monochromeParameterIsMaintainedIfNotSpecified() {
+        params.setMonochrome(false);
+        params.overrideMonochrome(new RuntimeOptions("--glue somewhere,somewhere.else").isMonochrome());
+        assertThat(params.isMonochrome(), equalTo(false));
+    }
+
+    @Test
+    public void monochromeParameterIsMaintainedIfNotSpecified2() {
+        params.setMonochrome(true);
+        params.overrideMonochrome(new RuntimeOptions("--glue somewhere,somewhere.else").isMonochrome());
         assertThat(params.isMonochrome(), equalTo(true));
     }
 }

--- a/src/test/java/com/github/timm/cucumber/generate/PluginTest.java
+++ b/src/test/java/com/github/timm/cucumber/generate/PluginTest.java
@@ -1,0 +1,158 @@
+package com.github.timm.cucumber.generate;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.CoreMatchers.nullValue;
+import static org.junit.Assert.assertThat;
+
+import org.junit.Test;
+
+import java.io.File;
+
+public class PluginTest {
+
+    @Test
+    public void shouldCreateBuildInPlugin() {
+        assertThat(Plugin.createBuildInPlugin("html"), notNullValue());
+    }
+
+    @Test
+    public void shouldCreatePluginWithoutOutput() {
+        assertThat(Plugin.createPluginWithoutOutput("quite").isNoOutput(), is(true));
+    }
+
+    @Test
+    public void applyDefaultAddsOutputDirectoryWhenAbsent() {
+        Plugin plugin = new Plugin();
+        plugin.setName("path.to.my.XmlFormatter");
+        plugin.applyDefaults(new File("path/to/output"));
+        assertThat(plugin.getOutputDirectory(), equalTo(new File("path/to/output")));
+    }
+
+    @Test
+    public void applyDefaultRespectsOutputDirectoryWhenPresent() {
+        Plugin plugin = new Plugin();
+        plugin.setName("path.to.my.XmlFormatter");
+        plugin.setOutputDirectory(new File("path/to/output"));
+        plugin.applyDefaults(new File("path/to/other/output"));
+        assertThat(plugin.getOutputDirectory(), equalTo(new File("path/to/output")));
+    }
+
+
+    @Test
+    public void applyDefaultsCorrectsNoOutputIfExtensionIsPresent() {
+        Plugin plugin = new Plugin();
+        plugin.setName("path.to.my.XmlFormatter");
+        plugin.setExtension("xml");
+        plugin.setNoOutput(true);
+
+        plugin.applyDefaults(new File("path/to/output"));
+        assertThat(plugin.isNoOutput(), equalTo(false));
+    }
+
+    @Test
+    public void applyDefaultsCorrectsNoOutputIfExtensionIsNotPresent() {
+        Plugin plugin = new Plugin();
+        plugin.setName("path.to.my.SilentFormatter");
+        plugin.setNoOutput(true);
+
+        plugin.applyDefaults(new File("path/to/output"));
+        assertThat(plugin.isNoOutput(), equalTo(true));
+    }
+
+    @Test
+    public void applyDefaultsCorrectsNoOutputIfOutputDirectoryIsPresent() {
+        Plugin plugin = new Plugin();
+        plugin.setName("path.to.my.XmlFormatter");
+        plugin.setOutputDirectory(new File("path/to/output"));
+        plugin.setNoOutput(true);
+
+        plugin.applyDefaults(new File("path/to/other/output"));
+        assertThat(plugin.isNoOutput(), equalTo(false));
+    }
+
+    @Test
+    public void applyDefaultsCorrectsNoOutputIfOutputDirectoryIsNotPresent() {
+        Plugin plugin = new Plugin();
+        plugin.setName("path.to.my.SilentFormatter");
+        plugin.setNoOutput(true);
+        plugin.applyDefaults(new File("path/to/other/output"));
+        assertThat(plugin.isNoOutput(), equalTo(true));
+    }
+
+    @Test
+    public void applyDefaultsIgnoresExtensionForBuildInPluginsWithNoOutput() {
+        Plugin plugin = Plugin.createBuildInPlugin("pretty");
+        plugin.setExtension("txt");
+        plugin.applyDefaults(new File("path/to/other/output"));
+        assertThat(plugin.isNoOutput(), equalTo(true));
+        assertThat(plugin.getExtension(), nullValue());
+        assertThat(plugin.getOutputDirectory(), nullValue());
+    }
+
+    @Test
+    public void applyDefaultsIgnoresOutputDirectoryForBuildInPluginsWithNoOutput() {
+        Plugin plugin = Plugin.createBuildInPlugin("pretty");
+        plugin.setOutputDirectory(new File("path/to/output"));
+        plugin.applyDefaults(new File("path/to/other/output"));
+        assertThat(plugin.isNoOutput(), equalTo(true));
+        assertThat(plugin.getExtension(), nullValue());
+        assertThat(plugin.getOutputDirectory(), nullValue());
+    }
+
+
+    @Test
+    public void applyDefaultSetsExtensionForBuildInWhenAbsent() {
+        Plugin plugin = new Plugin();
+        plugin.setName("json");
+        plugin.applyDefaults(new File("path/to/output"));
+        assertThat(plugin.getExtension(), equalTo("json"));
+    }
+
+    @Test
+    public void applyDefaultRespectsExtensionForBuildInWhenPresent() {
+        Plugin plugin = new Plugin();
+        plugin.setName("json");
+        plugin.setExtension("somethingelse");
+        plugin.applyDefaults(new File("path/to/output"));
+        assertThat(plugin.getExtension(), equalTo("somethingelse"));
+    }
+
+    @Test
+    public void applyDefaultAlwaysCorrectsNoOutputForBuildIn() {
+        Plugin plugin = new Plugin();
+        plugin.setName("json");
+        plugin.setNoOutput(true);
+        plugin.applyDefaults(new File("path/to/output"));
+        assertThat(plugin.isNoOutput(), equalTo(false));
+    }
+
+
+    @Test
+    public void asPluginStringForNoOutPut() {
+        Plugin plugin = new Plugin();
+        plugin.setName("pretty");
+        plugin.applyDefaults(new File("path/to/output"));
+        assertThat(plugin.asPluginString(42), equalTo("pretty"));
+    }
+
+    @Test
+    public void asPluginStringForNoExtension() {
+        Plugin plugin = new Plugin();
+        plugin.setName("html");
+        plugin.applyDefaults(new File("path/to/output"));
+        assertThat(plugin.asPluginString(42), equalTo("html:path/to/output/42"));
+    }
+
+    @Test
+    public void asPluginString() {
+        Plugin plugin = new Plugin();
+        plugin.setName("json");
+        plugin.applyDefaults(new File("path/to/output"));
+        assertThat(plugin.asPluginString(42), equalTo("json:path/to/output/42.json"));
+    }
+
+
+
+}

--- a/src/test/java/com/github/timm/cucumber/generate/TestFileGeneratorConfig.java
+++ b/src/test/java/com/github/timm/cucumber/generate/TestFileGeneratorConfig.java
@@ -4,7 +4,7 @@ import org.apache.maven.plugin.logging.Log;
 
 import java.io.File;
 
-public class TestFileGeneratorConfig implements FileGeneratorConfig {
+class TestFileGeneratorConfig implements FileGeneratorConfig {
 
     private boolean filterFeatureByTags = false;
     private Log log;
@@ -15,12 +15,12 @@ public class TestFileGeneratorConfig implements FileGeneratorConfig {
     private final String namingPattern = null;
     private final String customVmTemplate = "";
 
-    public TestFileGeneratorConfig setFeaturesDirectory(final File directory) {
+    TestFileGeneratorConfig setFeaturesDirectory(final File directory) {
         this.featuresDirectory = directory;
         return this;
     }
 
-    public TestFileGeneratorConfig setCucumberOutputDir(final Class<?> classUnderTest) {
+    TestFileGeneratorConfig setCucumberOutputDir(final Class<?> classUnderTest) {
         this.outputDir = new File("target", classUnderTest.getSimpleName());
         return this;
     }
@@ -33,10 +33,6 @@ public class TestFileGeneratorConfig implements FileGeneratorConfig {
         return log;
     }
 
-    public File getFeaturesDirectory() {
-        return featuresDirectory;
-    }
-
     public String getEncoding() {
         return "UTF-8";
     }
@@ -47,14 +43,6 @@ public class TestFileGeneratorConfig implements FileGeneratorConfig {
 
     public boolean useTestNG() {
         return useTestNg;
-    }
-
-    public String getNamingScheme() {
-        return namingScheme;
-    }
-
-    public String getNamingPattern() {
-        return namingPattern;
     }
 
     public String getCustomVmTemplate() {

--- a/src/test/java/com/github/timm/cucumber/options/RuntimeOptionsTest.java
+++ b/src/test/java/com/github/timm/cucumber/options/RuntimeOptionsTest.java
@@ -1,29 +1,25 @@
 package com.github.timm.cucumber.options;
 
-import static java.util.Arrays.asList;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
-
 import org.junit.Test;
 
-import java.util.Arrays;
 import java.util.List;
+
+import static java.util.Arrays.asList;
+import static java.util.Collections.singletonList;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 /**
  * Copyright (c) 2008-2014 The Cucumber Organisation Adapted from Cucumbers RuntimeOptionsTest
  */
 public class RuntimeOptionsTest {
 
-    private static final String CUCUMBER_OPTS_WITH_MULTI_WHITESPACE_BETWEEN_ARGS =
-                    "--format html --tags   @tag1,@tag2      --tags      @foo";
-
 
     @Test
     public void assigns_filters_from_tags() {
         final RuntimeOptions options = new RuntimeOptions("--tags @keep_this somewhere_else:3");
-        assertEquals(Arrays.<Object>asList("@keep_this"), options.getFilters());
+        assertEquals(singletonList("@keep_this"), options.getFilters());
     }
 
     @Test
@@ -36,7 +32,7 @@ public class RuntimeOptionsTest {
     @Test
     public void assigns_glue() {
         final RuntimeOptions options = new RuntimeOptions("--glue somewhere");
-        assertEquals(asList("somewhere"), options.getGlue());
+        assertEquals(singletonList("somewhere"), options.getGlue());
     }
 
     @Test
@@ -68,12 +64,6 @@ public class RuntimeOptionsTest {
     }
 
     @Test
-    public void default_strict() {
-        final RuntimeOptions options = new RuntimeOptions(asList("--glue", "somewhere"));
-        assertFalse(options.isStrict());
-    }
-
-    @Test
     public void unknown_options_are_ignored() {
         try {
             new RuntimeOptions(asList("-concreteUnsupportedOption", "somewhere", "somewhere_else"));
@@ -85,9 +75,9 @@ public class RuntimeOptionsTest {
     @Test
     public void shouldParseTagsWhenMultipleWhitespaceBetweenOptionArgs() {
         final RuntimeOptions parser =
-                        new RuntimeOptions(CUCUMBER_OPTS_WITH_MULTI_WHITESPACE_BETWEEN_ARGS);
+                        new RuntimeOptions("--format html --tags   @tag1,@tag2      --tags      @foo");
         final List<String> tags = parser.getFilters();
-        assertEquals(Arrays.asList("@tag1,@tag2", "@foo"), tags);
+        assertEquals(asList("@tag1,@tag2", "@foo"), tags);
     }
 
 


### PR DESCRIPTION
Using the  plugins element we can now support custom cucumber plugins. This should be backwards compatible.

Plugins can also be provided through `-Dcucumber.options`. To avoid over complicating everything this (for now)
has been explicitly limited to build-in cucumber plugins. This was previously implicitly limited.

 OverriddenCucumberOptionsParameters and RuntimeOptions have been refactored to allow the overrides to
 happen in GenerateRunnersMojo . This was needed because otherwise the default cucumber output directory
 needed to be passed down.

 A minor error has been corrected with regards to the html formatter. The html formatter create a folder
 rather then a file and as such does not need the html extension. The multiple-format integration tests have
 been changed to reflect this.