### PR TITLE
Remove filterFeaturesByTags property

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
 
 	<groupId>com.github.temyers</groupId>
 	<artifactId>cucumber-jvm-parallel-plugin</artifactId>
-	<version>3.0.1-SNAPSHOT</version>
+	<version>4.0.0-SNAPSHOT</version>
 	<packaging>maven-plugin</packaging>
 
 	<name>cucumber-jvm-parallel-plugin Maven Plugin</name>

--- a/readme.md
+++ b/readme.md
@@ -190,6 +190,12 @@ Q. Why isn't there much activity on this project
 A. The plugin is considered feature complete.  If you feel there is something missing, raise an issue.
 
 
+Migration from version 3.x
+==========================
+* The `filterFeaturesByTags` property has been removed. If you have not set this property to true 
+  remove any tags from your configuration. If you have set it to true you  can safely remove it.
+
+
 Migration from version 2.x
 ==========================
 * The `glue` property now takes a list of `package` elements rather then a list of comma delimited packages. A 
@@ -211,11 +217,17 @@ Migration from version 1.x
 
 Changelog
 =========
+
+4.0.0
+-----
+* PR #105 - Remove filterFeaturesByTags property. Fix issue #77
+
 3.0.0
 -----
-* PR #99 - Escape Java using Velocity engine: Fix issue #82
+* PR #99  - Escape Java using Velocity engine. Fix issue #82
 * PR #100 - Used containerized builds and cache dependencies
-* PR #104 - Add support for custom cucumber plugins.  Fix issue #95
+* PR #104 - Add support for custom cucumber plugins. Fix issue #95
+
 
 2.2.0
 -----

--- a/src/it/junit/custom-output-directory/pom.xml
+++ b/src/it/junit/custom-output-directory/pom.xml
@@ -48,10 +48,6 @@
                         <package>foo</package>
                         <package>bar</package>
                     </glue>
-                    <tags>
-                        <tag>@complete</tag>
-                        <tag>@accepted</tag>
-                    </tags>
                     <cucumberOutputDir>target/my-custom-dir</cucumberOutputDir>
                 </configuration>
             </plugin>

--- a/src/it/junit/custom-output-directory/verify.groovy
+++ b/src/it/junit/custom-output-directory/verify.groovy
@@ -25,7 +25,7 @@ import cucumber.api.junit.Cucumber;
         features = {"${feature1.absolutePath}"},
         plugin = {"json:${buildDirectory.absolutePath}/my-custom-dir/1.json"},
         monochrome = false,
-        tags = {"@complete", "@accepted"},
+        tags = {},
         glue = {"foo", "bar"})
 public class Parallel01IT {
 }"""
@@ -42,7 +42,7 @@ import cucumber.api.junit.Cucumber;
         features = {"${feature2.absolutePath}"},
         plugin = {"json:${buildDirectory.absolutePath}/my-custom-dir/2.json"},
         monochrome = false,
-        tags = {"@complete", "@accepted"},
+        tags = {},
         glue = {"foo", "bar"})
 public class Parallel02IT {
 }"""

--- a/src/it/junit/custom-package/pom.xml
+++ b/src/it/junit/custom-package/pom.xml
@@ -46,10 +46,6 @@
                                 <package>foo</package>
                                 <package>bar</package>
                             </glue>
-                            <tags>
-                                <tag>@complete</tag>
-                                <tag>@accepted</tag>
-                            </tags>
                             <packageName>foo.bar</packageName>
                         </configuration>
                     </execution>

--- a/src/it/junit/custom-package/verify.groovy
+++ b/src/it/junit/custom-package/verify.groovy
@@ -27,7 +27,7 @@ import cucumber.api.junit.Cucumber;
         features = {"${feature1.absolutePath}"},
         plugin = {"json:${buildDirectory.absolutePath}/cucumber-parallel/1.json"},
         monochrome = false,
-        tags = {"@complete", "@accepted"},
+        tags = {},
         glue = {"foo", "bar"})
 public class Parallel01IT {
 }"""
@@ -46,7 +46,7 @@ import cucumber.api.junit.Cucumber;
         features = {"${feature2.absolutePath}"},
         plugin = {"json:${buildDirectory.absolutePath}/cucumber-parallel/2.json"},
         monochrome = false,
-        tags = {"@complete", "@accepted"},
+        tags = {},
         glue = {"foo", "bar"})
 public class Parallel02IT {
 }"""

--- a/src/it/junit/filter-by-tag/pom.xml
+++ b/src/it/junit/filter-by-tag/pom.xml
@@ -50,7 +50,6 @@
                                 <!-- Only 1 feature contains this tag -->
                                 <tag>@feature1</tag>
                             </tags>
-                            <filterFeaturesByTags>true</filterFeaturesByTags>
                         </configuration>
                     </execution>
                 </executions>

--- a/src/it/junit/filter-by-tag2-negation/pom.xml
+++ b/src/it/junit/filter-by-tag2-negation/pom.xml
@@ -50,7 +50,6 @@
                                 <!-- Negation - filter out scenarios tagged with @feature1 -->
                                 <tag>~@feature1</tag>
                             </tags>
-                            <filterFeaturesByTags>true</filterFeaturesByTags>
                         </configuration>
                     </execution>
                 </executions>

--- a/src/it/junit/filter-by-tag3-and/pom.xml
+++ b/src/it/junit/filter-by-tag3-and/pom.xml
@@ -51,7 +51,6 @@
                                 <tag>@feature1</tag>
                                 <tag>@required</tag>
                             </tags>
-                            <filterFeaturesByTags>true</filterFeaturesByTags>
                         </configuration>
                     </execution>
                 </executions>

--- a/src/it/junit/filter-by-tag3-or/pom.xml
+++ b/src/it/junit/filter-by-tag3-or/pom.xml
@@ -50,7 +50,6 @@
                                 <!-- @feature1 OR @feature2 -->
                                 <tag>@feature1,@feature2</tag>
                             </tags>
-                            <filterFeaturesByTags>true</filterFeaturesByTags>
                         </configuration>
                     </execution>
                 </executions>

--- a/src/it/junit/filter-by-tag4/pom.xml
+++ b/src/it/junit/filter-by-tag4/pom.xml
@@ -51,7 +51,6 @@
                                 <tag>~@unwanted</tag>
                                 <tag>@includeMe</tag>
                             </tags>
-                            <filterFeaturesByTags>true</filterFeaturesByTags>
                         </configuration>
                     </execution>
                 </executions>

--- a/src/it/junit/filter-by-tag5-keep-tags-if-no-tags-in-cucumber-opts/pom.xml
+++ b/src/it/junit/filter-by-tag5-keep-tags-if-no-tags-in-cucumber-opts/pom.xml
@@ -51,7 +51,6 @@
                                 <!-- Only 1 feature contains this tag -->
                                 <tag>@feature1</tag>
                             </tags>
-                            <filterFeaturesByTags>true</filterFeaturesByTags>
                         </configuration>
                     </execution>
                 </executions>

--- a/src/it/junit/filter-by-tag6-override-tags-if-tags-in-cucumber-opts/pom.xml
+++ b/src/it/junit/filter-by-tag6-override-tags-if-tags-in-cucumber-opts/pom.xml
@@ -51,7 +51,6 @@
                                 <!-- Only 1 feature contains this tag -->
                                 <tag>@feature1</tag>
                             </tags>
-                            <filterFeaturesByTags>true</filterFeaturesByTags>
                         </configuration>
                     </execution>
                 </executions>

--- a/src/it/junit/illegal-escape-char/pom.xml
+++ b/src/it/junit/illegal-escape-char/pom.xml
@@ -46,10 +46,6 @@
                                 <package>foo</package>
                                 <package>bar</package>
                             </glue>
-                            <tags>
-                                <tag>@complete</tag>
-                                <tag>@accepted</tag>
-                            </tags>
                             <cucumberOutputDir>target\cucumber-reports</cucumberOutputDir>
                         </configuration>
                     </execution>

--- a/src/it/junit/illegal-escape-char/verify.groovy
+++ b/src/it/junit/illegal-escape-char/verify.groovy
@@ -22,7 +22,7 @@ import cucumber.api.junit.Cucumber;
         features = {"${feature.absolutePath}"},
         plugin = {"json:${buildDirectory.absolutePath}/cucumber-reports/1.json"},
         monochrome = false,
-        tags = {"@complete", "@accepted"},
+        tags = {},
         glue = {"foo", "bar"})
 public class Parallel01IT {
 }"""

--- a/src/it/junit/issue_15-feature-naming-scheme/pom.xml
+++ b/src/it/junit/issue_15-feature-naming-scheme/pom.xml
@@ -46,10 +46,6 @@
                                 <package>foo</package>
                                 <package>bar</package>
                             </glue>
-                            <tags>
-                                <tag>@complete</tag>
-                                <tag>@accepted</tag>
-                            </tags>
                             <namingScheme>feature-title</namingScheme>
                         </configuration>
                     </execution>

--- a/src/it/junit/issue_15-feature-naming-scheme/verify.groovy
+++ b/src/it/junit/issue_15-feature-naming-scheme/verify.groovy
@@ -25,7 +25,7 @@ import cucumber.api.junit.Cucumber;
         features = {"${feature1.absolutePath}"},
         plugin = {"json:${buildDirectory.absolutePath}/cucumber-parallel/1.json"},
         monochrome = false,
-        tags = {"@complete", "@accepted"},
+        tags = {},
         glue = {"foo", "bar"})
 public class Feature101IT {
 }"""
@@ -42,7 +42,7 @@ import cucumber.api.junit.Cucumber;
         features = {"${feature2.absolutePath}"},
         plugin = {"json:${buildDirectory.absolutePath}/cucumber-parallel/2.json"},
         monochrome = false,
-        tags = {"@complete", "@accepted"},
+        tags = {},
         glue = {"foo", "bar"})
 public class Feature202IT {
 }"""

--- a/src/it/junit/issue_19-complex-naming-scheme/pom.xml
+++ b/src/it/junit/issue_19-complex-naming-scheme/pom.xml
@@ -46,10 +46,6 @@
                                 <package>foo</package>
                                 <package>bar</package>
                             </glue>
-                            <tags>
-                                <tag>@complete</tag>
-                                <tag>@accepted</tag>
-                            </tags>
                             <namingScheme>pattern</namingScheme>
                             <namingPattern>Foo{f}{c}IT</namingPattern>
                         </configuration>

--- a/src/it/junit/issue_19-complex-naming-scheme/verify.groovy
+++ b/src/it/junit/issue_19-complex-naming-scheme/verify.groovy
@@ -25,7 +25,7 @@ import cucumber.api.junit.Cucumber;
         features = {"${feature1.absolutePath}"},
         plugin = {"json:${buildDirectory.absolutePath}/cucumber-parallel/1.json"},
         monochrome = false,
-        tags = {"@complete", "@accepted"},
+        tags = {},
         glue = {"foo", "bar"})
 public class FooFeature101IT {
 }"""
@@ -42,7 +42,7 @@ import cucumber.api.junit.Cucumber;
         features = {"${feature2.absolutePath}"},
         plugin = {"json:${buildDirectory.absolutePath}/cucumber-parallel/2.json"},
         monochrome = false,
-        tags = {"@complete", "@accepted"},
+        tags = {},
         glue = {"foo", "bar"})
 public class FooFeature202IT {
 }"""

--- a/src/it/junit/issue_19-multiple-execution/pom.xml
+++ b/src/it/junit/issue_19-multiple-execution/pom.xml
@@ -42,10 +42,6 @@
                             <goal>generateRunners</goal>
                         </goals>
                         <configuration>
-                            <tags>
-                                <tag>@complete</tag>
-                                <tag>@accepted</tag>
-                            </tags>
                             <glue>
                                 <package>foo</package>
                             </glue>
@@ -58,10 +54,6 @@
                             <goal>generateRunners</goal>
                         </goals>
                         <configuration>
-                            <tags>
-                                <tag>@complete</tag>
-                                <tag>@accepted</tag>
-                            </tags>
                             <glue>
                                 <package>bar</package>
                             </glue>

--- a/src/it/junit/issue_43-outline_runner-filter-by-tag/pom.xml
+++ b/src/it/junit/issue_43-outline_runner-filter-by-tag/pom.xml
@@ -58,7 +58,6 @@
                                 <package>com.github.timm</package>
                             </glue>
                             <parallelScheme>SCENARIO</parallelScheme>
-                            <filterFeaturesByTags>true</filterFeaturesByTags>
                             <tags>
                                 <tag>@outlineTag</tag>
                             </tags>

--- a/src/it/junit/multiple-format/pom.xml
+++ b/src/it/junit/multiple-format/pom.xml
@@ -47,10 +47,6 @@
                     <glue>
                         <package>foo</package>
                     </glue>
-                    <tags>
-                        <tag>@complete</tag>
-                        <tag>@accepted</tag>
-                    </tags>
                     <format>html,json,pretty</format>
                 </configuration>
             </plugin>

--- a/src/it/junit/multiple-format/verify.groovy
+++ b/src/it/junit/multiple-format/verify.groovy
@@ -25,7 +25,7 @@ import cucumber.api.junit.Cucumber;
         features = {"${feature1.absolutePath}"},
         plugin = {"html:${buildDirectory.absolutePath}/cucumber-parallel/1", "json:${buildDirectory.absolutePath}/cucumber-parallel/1.json", "pretty"},
         monochrome = false,
-        tags = {"@complete", "@accepted"},
+        tags = {},
         glue = {"foo"})
 public class Parallel01IT {
 }"""
@@ -42,7 +42,7 @@ import cucumber.api.junit.Cucumber;
         features = {"${feature2.absolutePath}"},
         plugin = {"html:${buildDirectory.absolutePath}/cucumber-parallel/2", "json:${buildDirectory.absolutePath}/cucumber-parallel/2.json", "pretty"},
         monochrome = false,
-        tags = {"@complete", "@accepted"},
+        tags = {},
         glue = {"foo"})
 public class Parallel02IT {
 }"""

--- a/src/it/junit/simple-it/pom.xml
+++ b/src/it/junit/simple-it/pom.xml
@@ -46,10 +46,6 @@
                                 <package>foo</package>
                                 <package>bar</package>
                             </glue>
-                            <tags>
-                                <tag>@complete</tag>
-                                <tag>@accepted</tag>
-                            </tags>
                         </configuration>
                     </execution>
                 </executions>

--- a/src/it/junit/simple-it/verify.groovy
+++ b/src/it/junit/simple-it/verify.groovy
@@ -25,7 +25,7 @@ import cucumber.api.junit.Cucumber;
         features = {"${feature1.absolutePath}"},
         plugin = {"json:${buildDirectory.absolutePath}/cucumber-parallel/1.json"},
         monochrome = false,
-        tags = {"@complete", "@accepted"},
+        tags = {},
         glue = {"foo", "bar"})
 public class Parallel01IT {
 }"""
@@ -42,7 +42,7 @@ import cucumber.api.junit.Cucumber;
         features = {"${feature2.absolutePath}"},
         plugin = {"json:${buildDirectory.absolutePath}/cucumber-parallel/2.json"},
         monochrome = false,
-        tags = {"@complete", "@accepted"},
+        tags = {},
         glue = {"foo", "bar"})
 public class Parallel02IT {
 }"""

--- a/src/it/testng/filter-by-tag/pom.xml
+++ b/src/it/testng/filter-by-tag/pom.xml
@@ -50,7 +50,6 @@
                                 <!-- Only 1 feature contains this tag -->
                                 <tag>@feature1</tag>
                             </tags>
-                            <filterFeaturesByTags>true</filterFeaturesByTags>
                             <useTestNG>true</useTestNG>
                         </configuration>
                     </execution>

--- a/src/it/testng/filter-by-tag5-keep-tags-if-no-tags-in-cucumber-opts/pom.xml
+++ b/src/it/testng/filter-by-tag5-keep-tags-if-no-tags-in-cucumber-opts/pom.xml
@@ -51,7 +51,6 @@
                                 <!-- Only 1 feature contains this tag -->
                                 <tag>@feature1</tag>
                             </tags>
-                            <filterFeaturesByTags>true</filterFeaturesByTags>
                             <useTestNG>true</useTestNG>
                         </configuration>
                     </execution>

--- a/src/it/testng/filter-by-tag6-override-tags-if-tags-in-cucumber-opts/pom.xml
+++ b/src/it/testng/filter-by-tag6-override-tags-if-tags-in-cucumber-opts/pom.xml
@@ -51,7 +51,6 @@
                                 <!-- Only 1 feature contains this tag -->
                                 <tag>@feature1</tag>
                             </tags>
-                            <filterFeaturesByTags>true</filterFeaturesByTags>
                             <useTestNG>true</useTestNG>
                         </configuration>
                     </execution>

--- a/src/it/testng/illegal-escape-char/pom.xml
+++ b/src/it/testng/illegal-escape-char/pom.xml
@@ -46,10 +46,6 @@
                                 <package>foo</package>
                                 <package>bar</package>
                             </glue>
-                            <tags>
-                                <tag>@complete</tag>
-                                <tag>@accepted</tag>
-                            </tags>
                             <cucumberOutputDir>target\cucumber-reports</cucumberOutputDir>
                             <useTestNG>true</useTestNG>
                         </configuration>

--- a/src/it/testng/illegal-escape-char/verify.groovy
+++ b/src/it/testng/illegal-escape-char/verify.groovy
@@ -19,7 +19,7 @@ import cucumber.api.testng.AbstractTestNGCucumberTests;
         features = {"${feature.absolutePath}"},
         plugin = {"json:${buildDirectory.absolutePath}/cucumber-reports/1.json"},
         monochrome = false,
-        tags = {"@complete", "@accepted"},
+        tags = {},
         glue = {"foo", "bar"})
 public class Parallel01IT extends AbstractTestNGCucumberTests {
 }"""

--- a/src/it/testng/issue_15-feature-naming-scheme/pom.xml
+++ b/src/it/testng/issue_15-feature-naming-scheme/pom.xml
@@ -46,10 +46,6 @@
                                 <package>foo</package>
                                 <package>bar</package>
                             </glue>
-                            <tags>
-                                <tag>@complete</tag>
-                                <tag>@accepted</tag>
-                            </tags>
                             <namingScheme>feature-title</namingScheme>
                             <useTestNG>true</useTestNG>
                         </configuration>

--- a/src/it/testng/issue_15-feature-naming-scheme/verify.groovy
+++ b/src/it/testng/issue_15-feature-naming-scheme/verify.groovy
@@ -21,7 +21,7 @@ import cucumber.api.testng.AbstractTestNGCucumberTests;
         features = {"${feature1.absolutePath}"},
         plugin = {"json:${buildDirectory.absolutePath}/cucumber-parallel/1.json"},
         monochrome = false,
-        tags = {"@complete", "@accepted"},
+        tags = {},
         glue = {"foo", "bar"})
 public class Feature101IT extends AbstractTestNGCucumberTests {
 }"""
@@ -34,7 +34,7 @@ import cucumber.api.testng.AbstractTestNGCucumberTests;
         features = {"${feature2.absolutePath}"},
         plugin = {"json:${buildDirectory.absolutePath}/cucumber-parallel/2.json"},
         monochrome = false,
-        tags = {"@complete", "@accepted"},
+        tags = {},
         glue = {"foo", "bar"})
 public class Feature202IT extends AbstractTestNGCucumberTests {
 }"""

--- a/src/it/testng/multiple-format/pom.xml
+++ b/src/it/testng/multiple-format/pom.xml
@@ -47,10 +47,6 @@
                     <glue>
                         <package>foo</package>
                     </glue>
-                    <tags>
-                        <tag>@complete</tag>
-                        <tag>@accepted</tag>
-                    </tags>
                     <format>html,json,pretty</format>
                     <useTestNG>true</useTestNG>
                 </configuration>

--- a/src/it/testng/multiple-format/verify.groovy
+++ b/src/it/testng/multiple-format/verify.groovy
@@ -22,7 +22,7 @@ import cucumber.api.testng.AbstractTestNGCucumberTests;
         features = {"${feature1.absolutePath}"},
         plugin = {"html:${buildDirectory.absolutePath}/cucumber-parallel/1", "json:${buildDirectory.absolutePath}/cucumber-parallel/1.json", "pretty"},
         monochrome = false,
-        tags = {"@complete", "@accepted"},
+        tags = {},
         glue = {"foo"})
 public class Parallel01IT extends AbstractTestNGCucumberTests {
 }"""
@@ -36,7 +36,7 @@ import cucumber.api.testng.AbstractTestNGCucumberTests;
         features = {"${feature2.absolutePath}"},
         plugin = {"html:${buildDirectory.absolutePath}/cucumber-parallel/2", "json:${buildDirectory.absolutePath}/cucumber-parallel/2.json", "pretty"},
         monochrome = false,
-        tags = {"@complete", "@accepted"},
+        tags = {},
         glue = {"foo"})
 public class Parallel02IT extends AbstractTestNGCucumberTests {
 }"""

--- a/src/it/testng/output-directory/pom.xml
+++ b/src/it/testng/output-directory/pom.xml
@@ -48,10 +48,6 @@
                         <package>foo</package>
                         <package>bar</package>
                     </glue>
-                    <tags>
-                        <tag>@complete</tag>
-                        <tag>@accepted</tag>
-                    </tags>
                     <cucumberOutputDir>target/my-custom-dir</cucumberOutputDir>
                     <useTestNG>true</useTestNG>
                 </configuration>

--- a/src/it/testng/output-directory/verify.groovy
+++ b/src/it/testng/output-directory/verify.groovy
@@ -22,7 +22,7 @@ import cucumber.api.testng.AbstractTestNGCucumberTests;
         features = {"${feature1.absolutePath}"},
         plugin = {"json:${buildDirectory.absolutePath}/my-custom-dir/1.json"},
         monochrome = false,
-        tags = {"@complete", "@accepted"},
+        tags = {},
         glue = {"foo", "bar"})
 public class Parallel01IT extends AbstractTestNGCucumberTests {
 }"""
@@ -36,7 +36,7 @@ import cucumber.api.testng.AbstractTestNGCucumberTests;
         features = {"${feature2.absolutePath}"},
         plugin = {"json:${buildDirectory.absolutePath}/my-custom-dir/2.json"},
         monochrome = false,
-        tags = {"@complete", "@accepted"},
+        tags = {},
         glue = {"foo", "bar"})
 public class Parallel02IT extends AbstractTestNGCucumberTests {
 }"""

--- a/src/it/testng/simple-it/pom.xml
+++ b/src/it/testng/simple-it/pom.xml
@@ -46,10 +46,6 @@
                                 <package>foo</package>
                                 <package>bar</package>
                             </glue>
-                            <tags>
-                                <tag>@complete</tag>
-                                <tag>@accepted</tag>
-                            </tags>
                             <useTestNG>true</useTestNG>
                         </configuration>
                     </execution>

--- a/src/it/testng/simple-it/verify.groovy
+++ b/src/it/testng/simple-it/verify.groovy
@@ -22,7 +22,7 @@ import cucumber.api.testng.AbstractTestNGCucumberTests;
         features = {"${feature1.absolutePath}"},
         plugin = {"json:${buildDirectory.absolutePath}/cucumber-parallel/1.json"},
         monochrome = false,
-        tags = {"@complete", "@accepted"},
+        tags = {},
         glue = {"foo", "bar"})
 public class Parallel01IT extends AbstractTestNGCucumberTests {
 }"""
@@ -36,7 +36,7 @@ import cucumber.api.testng.AbstractTestNGCucumberTests;
         features = {"${feature2.absolutePath}"},
         plugin = {"json:${buildDirectory.absolutePath}/cucumber-parallel/2.json"},
         monochrome = false,
-        tags = {"@complete", "@accepted"},
+        tags = {},
         glue = {"foo", "bar"})
 public class Parallel02IT extends AbstractTestNGCucumberTests {
 }"""

--- a/src/main/java/com/github/timm/cucumber/generate/CucumberITGeneratorByFeature.java
+++ b/src/main/java/com/github/timm/cucumber/generate/CucumberITGeneratorByFeature.java
@@ -140,7 +140,7 @@ public class CucumberITGeneratorByFeature implements CucumberITGenerator {
     }
 
     private boolean shouldSkipFeature(final Feature feature) {
-        if (config.filterFeaturesByTags()) {
+        if (!overriddenParameters.getTags().isEmpty()) {
             final TagFilter tagFilter = new TagFilter(overriddenParameters.getTags());
             if (tagFilter.matchingScenariosAndExamples(feature).isEmpty()) {
                 return true;

--- a/src/main/java/com/github/timm/cucumber/generate/CucumberITGeneratorByScenario.java
+++ b/src/main/java/com/github/timm/cucumber/generate/CucumberITGeneratorByScenario.java
@@ -166,9 +166,7 @@ public class CucumberITGeneratorByScenario implements CucumberITGenerator {
         context.put("strict", overriddenParameters.isStrict());
         context.put("featureFile", featureFileLocation);
         context.put("plugins", createPluginStrings());
-        if (!config.filterFeaturesByTags()) {
-            context.put("tags", overriddenParameters.getTags());
-        }
+        context.put("tags", overriddenParameters.getTags());
         context.put("monochrome", overriddenParameters.isMonochrome());
         context.put("cucumberOutputDir", normalizePathSeparator(config.getCucumberOutputDir()));
         context.put("glue", overriddenParameters.getGlue());

--- a/src/main/java/com/github/timm/cucumber/generate/FileGeneratorConfig.java
+++ b/src/main/java/com/github/timm/cucumber/generate/FileGeneratorConfig.java
@@ -4,9 +4,7 @@ import org.apache.maven.plugin.logging.Log;
 
 import java.io.File;
 
-public interface FileGeneratorConfig {
-
-    boolean filterFeaturesByTags();
+interface FileGeneratorConfig {
 
     Log getLog();
 

--- a/src/main/java/com/github/timm/cucumber/generate/GenerateRunnersMojo.java
+++ b/src/main/java/com/github/timm/cucumber/generate/GenerateRunnersMojo.java
@@ -158,9 +158,6 @@ public class GenerateRunnersMojo extends AbstractMojo implements FileGeneratorCo
     @Parameter(defaultValue = "UTF-8", property = "project.build.sourceEncoding", readonly = true)
     private String encoding;
 
-    @Parameter(defaultValue = "false", property = "cucumber.tags.filterOutput", required = true)
-    private boolean filterFeaturesByTags;
-
     @Parameter(defaultValue = "false", property = "useTestNG", required = true)
     private boolean useTestNG;
 
@@ -319,10 +316,6 @@ public class GenerateRunnersMojo extends AbstractMojo implements FileGeneratorCo
         }
 
         return plugins;
-    }
-
-    public boolean filterFeaturesByTags() {
-        return filterFeaturesByTags;
     }
 
     public String getEncoding() {

--- a/src/test/java/com/github/timm/cucumber/generate/TestFileGeneratorConfig.java
+++ b/src/test/java/com/github/timm/cucumber/generate/TestFileGeneratorConfig.java
@@ -6,7 +6,6 @@ import java.io.File;
 
 class TestFileGeneratorConfig implements FileGeneratorConfig {
 
-    private boolean filterFeatureByTags = false;
     private Log log;
     private File featuresDirectory;
     private File outputDir;
@@ -23,10 +22,6 @@ class TestFileGeneratorConfig implements FileGeneratorConfig {
     TestFileGeneratorConfig setCucumberOutputDir(final Class<?> classUnderTest) {
         this.outputDir = new File("target", classUnderTest.getSimpleName());
         return this;
-    }
-
-    public boolean filterFeaturesByTags() {
-        return filterFeatureByTags;
     }
 
     public Log getLog() {
@@ -47,11 +42,6 @@ class TestFileGeneratorConfig implements FileGeneratorConfig {
 
     public String getCustomVmTemplate() {
         return customVmTemplate;
-    }
-
-    public TestFileGeneratorConfig setFilterFeaturesByTags(final boolean newValue) {
-        this.filterFeatureByTags = newValue;
-        return this;
     }
 
     public String getPackageName() {


### PR DESCRIPTION
 The filterFeaturesByTags is superfluous. It must always be true when tags are present
 and should have no effect when there are none. This required a small breaking change
 to CucumberITGeneratorByFeature so it doesn't filter features unless there are tags
 to filter on.

 This resolves #77 .