### PR TITLE
Serenity integration

### DIFF
--- a/src/main/java/com/github/timm/cucumber/generate/CucumberITGeneratorByFeature.java
+++ b/src/main/java/com/github/timm/cucumber/generate/CucumberITGeneratorByFeature.java
@@ -76,6 +76,8 @@ public class CucumberITGeneratorByFeature implements CucumberITGenerator {
             name = config.getCustomVmTemplate();
         } else if (config.useTestNG()) {
             name = "cucumber-testng-runner.java.vm";
+        } else if (config.useSerenity()) {
+            name = "cucumber-serenity-runner.java.vm";
         } else {
             name = "cucumber-junit-runner.java.vm";
         }

--- a/src/main/java/com/github/timm/cucumber/generate/CucumberITGeneratorByScenario.java
+++ b/src/main/java/com/github/timm/cucumber/generate/CucumberITGeneratorByScenario.java
@@ -78,6 +78,8 @@ public class CucumberITGeneratorByScenario implements CucumberITGenerator {
             name = config.getCustomVmTemplate();
         } else if (config.useTestNG()) {
             name = "cucumber-testng-runner.java.vm";
+        } else if (config.useSerenity()) {
+            name = "cucumber-serenity-runner.java.vm";
         } else {
             name = "cucumber-junit-runner.java.vm";
         }

--- a/src/main/java/com/github/timm/cucumber/generate/FileGeneratorConfig.java
+++ b/src/main/java/com/github/timm/cucumber/generate/FileGeneratorConfig.java
@@ -14,6 +14,8 @@ interface FileGeneratorConfig {
 
     boolean useTestNG();
 
+    boolean useSerenity();
+
     String getCustomVmTemplate();
 
     String getPackageName();

--- a/src/main/java/com/github/timm/cucumber/generate/GenerateRunnersMojo.java
+++ b/src/main/java/com/github/timm/cucumber/generate/GenerateRunnersMojo.java
@@ -154,6 +154,9 @@ public class GenerateRunnersMojo extends AbstractMojo implements FileGeneratorCo
     @Parameter(defaultValue = "false", property = "useTestNG", required = true)
     private boolean useTestNG;
 
+    @Parameter(defaultValue = "false", property = "useSerenity", required = true)
+    private boolean useSerenity;
+
     /**
      * see cucumber.api.CucumberOptions
      */
@@ -321,6 +324,10 @@ public class GenerateRunnersMojo extends AbstractMojo implements FileGeneratorCo
 
     public boolean useTestNG() {
         return useTestNG;
+    }
+
+    public boolean useSerenity() {
+        return useSerenity;
     }
 
     public String getCustomVmTemplate() {

--- a/src/main/resources/cucumber-serenity-runner.java.vm
+++ b/src/main/resources/cucumber-serenity-runner.java.vm
@@ -1,0 +1,23 @@
+#parse("/array.java.vm")
+#if ($packageName)
+package $packageName;
+
+#end##
+import org.junit.runner.RunWith;
+
+import cucumber.api.CucumberOptions;
+import net.serenitybdd.cucumber.CucumberWithSerenity;
+import cucumber.api.junit.Cucumber;
+
+@RunWith(CucumberWithSerenity.class)
+@CucumberOptions(
+        strict = $strict,
+        features = {"$featureFile"},
+        plugin = #stringArray($plugins),
+        monochrome = $monochrome,
+#if(!$featureFile.contains(".feature:") && $tags)
+        tags = #stringArray($tags),
+#end
+        glue = #stringArray($glue))
+public class $className {
+}

--- a/src/test/java/com/github/timm/cucumber/generate/TestFileGeneratorConfig.java
+++ b/src/test/java/com/github/timm/cucumber/generate/TestFileGeneratorConfig.java
@@ -10,6 +10,7 @@ class TestFileGeneratorConfig implements FileGeneratorConfig {
     private File featuresDirectory;
     private File outputDir;
     private final boolean useTestNg = false;
+    private final boolean useSerenity = false;
     private final String namingScheme = "simple";
     private final String namingPattern = null;
     private final String customVmTemplate = "";
@@ -38,6 +39,10 @@ class TestFileGeneratorConfig implements FileGeneratorConfig {
 
     public boolean useTestNG() {
         return useTestNg;
+    }
+
+    public boolean useSerenity() {
+        return useSerenity;
     }
 
     public String getCustomVmTemplate() {


### PR DESCRIPTION
Hi guys,

In my current project we have a problem because we use Serenity and generated runners should have:
`@RunWith(CucumberWithSerenity.class)` annotation.

Currently plugin generates only runners with `@RunWith(Cucumber.class)` annotation what is not expected in this case.

I would like to have new option in config **useSerenity** which will generate runners with `@RunWith(CucumberWithSerenity.class)` annotation and required 
`import net.serenitybdd.cucumber.CucumberWithSerenity;`.

Do you have any suggestion how to resolve this problem as more generic solution? ... or is it ok?