### PR TITLE
allow scenario tags to be accessed by velocity template

### DIFF
--- a/src/it/junit/access-scenario-tags-from-velocity-template/custom-template-for-scenario-tags-test.vm
+++ b/src/it/junit/access-scenario-tags-from-velocity-template/custom-template-for-scenario-tags-test.vm
@@ -1,0 +1,2 @@
+#parse("/array.java.vm")
+// This is a custom template for $className with an array of tags $scenarioTags

--- a/src/it/junit/access-scenario-tags-from-velocity-template/pom.xml
+++ b/src/it/junit/access-scenario-tags-from-velocity-template/pom.xml
@@ -1,0 +1,59 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>com.github.temyers.it</groupId>
+    <artifactId>simple-it</artifactId>
+    <version>1.0-SNAPSHOT</version>
+
+    <description>An IT verifying we can access scenario tags fro the velocity template</description>
+
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <cucumber.version>1.2.2</cucumber.version>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>info.cukes</groupId>
+            <artifactId>cucumber-junit</artifactId>
+            <version>${cucumber.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>info.cukes</groupId>
+            <artifactId>cucumber-java</artifactId>
+            <version>${cucumber.version}</version>
+        </dependency>
+    </dependencies>
+
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>@project.groupId@</groupId>
+                <artifactId>@project.artifactId@</artifactId>
+                <version>@project.version@</version>
+                <executions>
+                    <execution>
+                        <id>generateRunners</id>
+                        <phase>generate-test-sources</phase>
+                        <goals>
+                            <goal>generateRunners</goal>
+                        </goals>
+                    </execution>
+                </executions>
+                <configuration>
+                    <glue>
+                        <package>foo</package>
+                        <package>bar</package>
+                    </glue>
+                    <customVmTemplate>custom-template-for-scenario-tags-test.vm</customVmTemplate>
+                    <parallelScheme>SCENARIO</parallelScheme>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>
+

--- a/src/it/junit/access-scenario-tags-from-velocity-template/src/test/resources/features/feature1.feature
+++ b/src/it/junit/access-scenario-tags-from-velocity-template/src/test/resources/features/feature1.feature
@@ -1,0 +1,13 @@
+@featuretag
+Feature: Feature1
+
+  @scenariotag1
+  Scenario: Generate File with tags from the scenario and feature level
+    Given I have feature files
+    When I generate Maven sources
+    Then the file "target/generated-test-sources/Parallel01IT.java" should exist
+    And it should contain:
+    """
+    // This is a custom template for Parallel01IT with an array of tags {"@featuretag", "@scenarioag1"}
+    """
+

--- a/src/it/junit/access-scenario-tags-from-velocity-template/src/test/resources/features/feature2.feature
+++ b/src/it/junit/access-scenario-tags-from-velocity-template/src/test/resources/features/feature2.feature
@@ -1,0 +1,22 @@
+@feature-tag2
+Feature: Feature2
+
+  @outline-tag
+  Scenario Outline:  Generate File with tags from the scenario, example and feature level
+    Given I have feature files
+    When I generate Maven sources
+    Then the file "target/generated-test-sources/"<file>" should exist
+    And it should contain:
+    """
+    // This is a custom template for Parallel01IT with an array of tags <tags>
+    """
+
+  @example1
+    Examples:
+      | file            | tags                                           |
+      | Parallel02IT    | {"@feature-tag2", "@outline-tag", "@example1"} |
+
+  @example2
+    Examples:
+      | file            | tags                                           |
+      | Parallel03IT    | {"@feature-tag2", "@outline-tag", "@example2"} |

--- a/src/it/junit/access-scenario-tags-from-velocity-template/verify.groovy
+++ b/src/it/junit/access-scenario-tags-from-velocity-template/verify.groovy
@@ -1,0 +1,66 @@
+import org.junit.Assert
+
+import static org.hamcrest.Matchers.equalToIgnoringWhiteSpace
+
+def outputPath = "target/generated-test-sources/cucumber/"
+File suite01 = new File(basedir, outputPath + "Parallel01IT.java")
+File suite02 = new File(basedir, outputPath + "Parallel02IT.java")
+File suite03 = new File(basedir, outputPath + "Parallel03IT.java")
+
+assert suite01.isFile()
+assert suite02.isFile()
+assert suite03.isFile()
+
+String expected01 = "// This is a custom template for Parallel01IT with an array of tags [@featuretag, @scenariotag1]"
+String expected02 = "// This is a custom template for Parallel02IT with an array of tags [@outline-tag, @feature-tag2, @example1]"
+String expected03 = "// This is a custom template for Parallel03IT with an array of tags [@example2, @outline-tag, @feature-tag2]"
+
+// The order of the files isn't important but listFiles may list files in any order
+// This ensures we assert correctly despite file ordering
+File actualSuite01;
+File actualSuite02;
+File actualSuite03;
+
+
+if (suite01.text.contains("01IT")) {
+    actualSuite01 = suite01
+
+    if (suite02.text.contains("02IT")) {
+        actualSuite02 = suite02
+        actualSuite03 = suite03
+    } else {
+        actualSuite02 = suite03
+        actualSuite03 = suite02
+    }
+
+} else if (suite01.text.contains("02IT")) {
+
+    actualSuite01 = suite01
+
+    if (suite02.text.contains("01IT")) {
+        actualSuite02 = suite01
+        actualSuite03 = suite03
+    } else {
+        actualSuite02 = suite03
+        actualSuite03 = suite01
+    }
+
+} else {
+    actualSuite01 = suite03
+
+    if (suite02.text.contains("01IT")) {
+        actualSuite02 = suite01
+        actualSuite03 = suite02
+    } else {
+        actualSuite02 = suite02
+        actualSuite03 = suite01
+    }
+
+}
+
+Assert.assertThat(actualSuite01.text, equalToIgnoringWhiteSpace(expected01))
+Assert.assertThat(actualSuite02.text, equalToIgnoringWhiteSpace(expected02))
+Assert.assertThat(actualSuite03.text, equalToIgnoringWhiteSpace(expected03))
+
+
+

--- a/src/main/java/com/github/timm/cucumber/generate/CucumberITGeneratorByScenario.java
+++ b/src/main/java/com/github/timm/cucumber/generate/CucumberITGeneratorByScenario.java
@@ -7,11 +7,12 @@ import com.github.timm.cucumber.generate.name.ClassNamingScheme;
 import gherkin.AstBuilder;
 import gherkin.Parser;
 import gherkin.TokenMatcher;
+
 import gherkin.ast.Feature;
 import gherkin.ast.Location;
 import gherkin.ast.Node;
 import gherkin.ast.ScenarioDefinition;
-
+import gherkin.ast.Tag;
 import org.apache.commons.io.FilenameUtils;
 import org.apache.commons.lang.StringUtils;
 import org.apache.commons.lang3.StringEscapeUtils;
@@ -30,8 +31,10 @@ import java.io.IOException;
 import java.io.Writer;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Properties;
+import java.util.Set;
 
 /**
  * Generates Cucumber runner files using configuration from FileGeneratorConfig containing parameters passed into the
@@ -49,6 +52,7 @@ public class CucumberITGeneratorByScenario implements CucumberITGenerator {
     private Template velocityTemplate;
     private String outputFileName;
     private final ClassNamingScheme classNamingScheme;
+    private Set<String> parsedScenarioTags;
 
 
     /**
@@ -118,6 +122,7 @@ public class CucumberITGeneratorByScenario implements CucumberITGenerator {
                 setFeatureFileLocation(file, match.getLocation());
                 setParsedFeature(feature);
                 setParsedScenario(match.getScenario());
+                setParsedScenarioTags(getTagsAsStrings(match.getTags()));
                 writeFile(outputDirectory);
             }
 
@@ -165,6 +170,10 @@ public class CucumberITGeneratorByScenario implements CucumberITGenerator {
         parsedScenario = scenario;
     }
 
+    private void setParsedScenarioTags(Set<String> scenarioTags) {
+        parsedScenarioTags = scenarioTags;
+    }
+
     private static String normalizePathSeparator(File file) {
         return file.getPath().replace(File.separatorChar, '/');
     }
@@ -187,6 +196,7 @@ public class CucumberITGeneratorByScenario implements CucumberITGenerator {
         context.put("packageName", config.getPackageName());
         context.put("feature", parsedFeature);
         context.put("scenario", parsedScenario);
+        context.put("scenarioTags", parsedScenarioTags);
 
         velocityTemplate.merge(context, writer);
     }
@@ -213,5 +223,17 @@ public class CucumberITGeneratorByScenario implements CucumberITGenerator {
             }
         }
     }
+
+
+    private Set<String> getTagsAsStrings(Set<Tag> tags) {
+        Set<String> stringTags = new HashSet<String>();
+
+        for (Tag tag: tags) {
+            stringTags.add(tag.getName());
+        }
+
+        return stringTags;
+    }
+
 
 }

--- a/src/main/java/com/github/timm/cucumber/generate/ScenarioAndLocation.java
+++ b/src/main/java/com/github/timm/cucumber/generate/ScenarioAndLocation.java
@@ -2,6 +2,8 @@ package com.github.timm.cucumber.generate;
 
 import gherkin.ast.Location;
 import gherkin.ast.ScenarioDefinition;
+import gherkin.ast.Tag;
+import java.util.Set;
 
 /**
  * A single test to create within a test run.
@@ -19,9 +21,21 @@ public class ScenarioAndLocation {
      */
     private final Location location;
 
-    public ScenarioAndLocation(ScenarioDefinition scenarioDefinition, Location location) {
+    /**
+     * The tags for this scenario - either from the scenario, the examples table or at feature level.
+     */
+    private final Set<Tag> tags;
+
+    /**
+     * Scenario object containing detail of the scenario, where the test came from and all the tags associated with it.
+     * @param scenarioDefinition
+     * @param location
+     * @param tags
+     */
+    public ScenarioAndLocation(ScenarioDefinition scenarioDefinition, Location location, Set<Tag> tags) {
         this.scenarioDefinition = scenarioDefinition;
         this.location = location;
+        this.tags = tags;
     }
 
     public ScenarioDefinition getScenario() {
@@ -31,4 +45,9 @@ public class ScenarioAndLocation {
     public Location getLocation() {
         return location;
     }
+
+    public Set<Tag> getTags() {
+        return tags;
+    }
+
 }

--- a/src/main/java/com/github/timm/cucumber/generate/filter/TagFilter.java
+++ b/src/main/java/com/github/timm/cucumber/generate/filter/TagFilter.java
@@ -104,7 +104,7 @@ public class TagFilter {
             } else {
                 if (matches(allTagsForScenario)) {
                     matchingScenariosAndExamples
-                                    .add(new ScenarioAndLocation(scenario, scenario.getLocation()));
+                                    .add(new ScenarioAndLocation(scenario, scenario.getLocation(), allTagsForScenario));
                 }
 
             }
@@ -124,7 +124,8 @@ public class TagFilter {
             allTagsForExample.addAll(example.getTags());
             if (matches(allTagsForExample)) {
                 for (TableRow row : example.getTableBody()) {
-                    matchingRows.add(new ScenarioAndLocation(scenario, row.getLocation()));
+                    matchingRows.add(new ScenarioAndLocation(scenario, row.getLocation(),
+                            (Set<Tag>) allTagsForExample));
                 }
             }
         }


### PR DESCRIPTION
Allow access of scenario tags from the velocity template, this would allow us to write custom velocity template based on the cucumber scenario/feature tags, for example the @ui tag could generate a runner that extends a class with webdriver setup functionality while a scenario without the @ui tag would generate a normal runner

eg [frameworkium-runner.txt](https://github.com/temyers/cucumber-jvm-parallel-plugin/files/1111823/frameworkium-runner.txt)