### PR TITLE
Modulo Counter enhancement

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -161,6 +161,7 @@ The naming scheme used for the generated files is controlled by the `namingSchem
 The following tokens can be used in the pattern:
 * `{f}` Converts the feature file name to a valid class name using the rules for feature-title, apart from the one up counter.
 * `{c}` Adds a one up counter. |
+* `{c:n}` Adds a one up counter modulo n (useful for selecting tests for parallelisation). |
 
 By default, generated test files use the `simple` naming strategy.
 

--- a/src/it/junit/modular-naming-pattern/pom.xml
+++ b/src/it/junit/modular-naming-pattern/pom.xml
@@ -1,0 +1,57 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>com.github.temyers.it</groupId>
+    <artifactId>simple-it</artifactId>
+    <version>1.0-SNAPSHOT</version>
+
+    <description>A simple IT verifying the basic use case.</description>
+
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <cucumber.version>1.2.2</cucumber.version>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>info.cukes</groupId>
+            <artifactId>cucumber-junit</artifactId>
+            <version>${cucumber.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>info.cukes</groupId>
+            <artifactId>cucumber-java</artifactId>
+            <version>${cucumber.version}</version>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>@project.groupId@</groupId>
+                <artifactId>@project.artifactId@</artifactId>
+                <version>@project.version@</version>
+                <executions>
+                    <execution>
+                        <id>generateRunners</id>
+                        <phase>generate-test-sources</phase>
+                        <goals>
+                            <goal>generateRunners</goal>
+                        </goals>
+                        <configuration>
+                            <glue>
+                                <package>foo</package>
+                                <package>bar</package>
+                            </glue>
+                            <namingScheme>pattern</namingScheme>
+                            <namingPattern>Group{c:3}Parallel{c}IT</namingPattern>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/src/it/junit/modular-naming-pattern/src/test/resources/features/feature1.feature
+++ b/src/it/junit/modular-naming-pattern/src/test/resources/features/feature1.feature
@@ -1,0 +1,20 @@
+Feature: Feature1
+
+  Scenario: Generate Junit Runner for each feature file
+    Given I have feature files
+    When I generate Maven sources
+    Then the file "target/generated-test-sources/1IT.java" should exist
+    And it should contain:
+    """
+    @RunWith(Cucumber.class)
+    @CucumberOptions(
+        strict = true,
+        features = {"classpath:features/feature1.feature"},
+        format = {"json:target/cucumber-parallel/1.json",
+    "pretty"},
+        monochrome = false,
+        tags = {"@complete", "@accepted"},
+        glue = {"foo", "bar"})
+    public class Parallel01IT {
+    }
+    """

--- a/src/it/junit/modular-naming-pattern/src/test/resources/features/feature2.feature
+++ b/src/it/junit/modular-naming-pattern/src/test/resources/features/feature2.feature
@@ -1,0 +1,19 @@
+Feature: Feature2
+
+  Scenario: Generate Junit Runner for each feature file
+    Given I have feature files
+    When I generate Maven sources
+    Then the file "target/generated-test-sources/1IT.java" should exist
+    And it should contain:
+    """
+    @RunWith(Cucumber.class)
+    @CucumberOptions(
+        strict = true,
+        features = {"classpath:features/feature2.feature"},
+        format = {"json:target/cucumber-parallel/2.json", "pretty"},
+        monochrome = false,
+        tags = {"@complete", "@accepted"},
+        glue = {"foo", "bar"})
+    public class Parallel02IT {
+    }
+    """

--- a/src/it/junit/modular-naming-pattern/src/test/resources/features/feature3.feature
+++ b/src/it/junit/modular-naming-pattern/src/test/resources/features/feature3.feature
@@ -1,0 +1,19 @@
+Feature: Feature3
+
+  Scenario: Generate Junit Runner for each feature file
+    Given I have feature files
+    When I generate Maven sources
+    Then the file "target/generated-test-sources/1IT.java" should exist
+    And it should contain:
+    """
+    @RunWith(Cucumber.class)
+    @CucumberOptions(
+        strict = true,
+        features = {"classpath:features/feature2.feature"},
+        format = {"json:target/cucumber-parallel/2.json", "pretty"},
+        monochrome = false,
+        tags = {"@complete", "@accepted"},
+        glue = {"foo", "bar"})
+    public class Parallel02IT {
+    }
+    """

--- a/src/it/junit/modular-naming-pattern/src/test/resources/features/feature4.feature
+++ b/src/it/junit/modular-naming-pattern/src/test/resources/features/feature4.feature
@@ -1,0 +1,20 @@
+Feature: Feature4
+
+  Scenario: Generate Junit Runner for each feature file
+    Given I have feature files
+    When I generate Maven sources
+    Then the file "target/generated-test-sources/1IT.java" should exist
+    And it should contain:
+    """
+    @RunWith(Cucumber.class)
+    @CucumberOptions(
+        strict = true,
+        features = {"classpath:features/feature1.feature"},
+        format = {"json:target/cucumber-parallel/1.json",
+    "pretty"},
+        monochrome = false,
+        tags = {"@complete", "@accepted"},
+        glue = {"foo", "bar"})
+    public class Parallel01IT {
+    }
+    """

--- a/src/it/junit/modular-naming-pattern/src/test/resources/features/feature5.feature
+++ b/src/it/junit/modular-naming-pattern/src/test/resources/features/feature5.feature
@@ -1,0 +1,19 @@
+Feature: Feature5
+
+  Scenario: Generate Junit Runner for each feature file
+    Given I have feature files
+    When I generate Maven sources
+    Then the file "target/generated-test-sources/1IT.java" should exist
+    And it should contain:
+    """
+    @RunWith(Cucumber.class)
+    @CucumberOptions(
+        strict = true,
+        features = {"classpath:features/feature2.feature"},
+        format = {"json:target/cucumber-parallel/2.json", "pretty"},
+        monochrome = false,
+        tags = {"@complete", "@accepted"},
+        glue = {"foo", "bar"})
+    public class Parallel02IT {
+    }
+    """

--- a/src/it/junit/modular-naming-pattern/src/test/resources/features/feature6.feature
+++ b/src/it/junit/modular-naming-pattern/src/test/resources/features/feature6.feature
@@ -1,0 +1,19 @@
+Feature: Feature6
+
+  Scenario: Generate Junit Runner for each feature file
+    Given I have feature files
+    When I generate Maven sources
+    Then the file "target/generated-test-sources/1IT.java" should exist
+    And it should contain:
+    """
+    @RunWith(Cucumber.class)
+    @CucumberOptions(
+        strict = true,
+        features = {"classpath:features/feature2.feature"},
+        format = {"json:target/cucumber-parallel/2.json", "pretty"},
+        monochrome = false,
+        tags = {"@complete", "@accepted"},
+        glue = {"foo", "bar"})
+    public class Parallel02IT {
+    }
+    """

--- a/src/it/junit/modular-naming-pattern/verify.groovy
+++ b/src/it/junit/modular-naming-pattern/verify.groovy
@@ -1,0 +1,64 @@
+import org.junit.Assert
+
+import static org.hamcrest.Matchers.equalToIgnoringWhiteSpace
+
+File buildDirectory = new File(basedir, "target");
+
+File suite01 = new File(basedir, "target/generated-test-sources/cucumber/Group0Parallel01IT.java")
+File suite02 = new File(basedir, "target/generated-test-sources/cucumber/Group1Parallel02IT.java")
+File suite03 = new File(basedir, "target/generated-test-sources/cucumber/Group2Parallel03IT.java")
+File suite04 = new File(basedir, "target/generated-test-sources/cucumber/Group0Parallel04IT.java")
+File suite05 = new File(basedir, "target/generated-test-sources/cucumber/Group1Parallel05IT.java")
+File suite06 = new File(basedir, "target/generated-test-sources/cucumber/Group2Parallel06IT.java")
+
+
+File feature1 = new File(basedir, "/src/test/resources/features/feature1.feature")
+File feature2 = new File(basedir, "/src/test/resources/features/feature2.feature")
+
+assert suite01.isFile()
+assert suite02.isFile()
+assert suite03.isFile()
+assert suite04.isFile()
+assert suite05.isFile()
+assert suite06.isFile()
+
+String expected01 =
+        """import org.junit.runner.RunWith;
+
+import cucumber.api.CucumberOptions;
+import cucumber.api.junit.Cucumber;
+
+@RunWith(Cucumber.class)
+@CucumberOptions(
+        strict = true,
+        features = {"${feature1.absolutePath}"},
+        plugin = {"json:${buildDirectory.absolutePath}/cucumber-parallel/1.json"},
+        monochrome = false,
+        tags = {},
+        glue = {"foo", "bar"})
+public class Group0Parallel01IT {
+}"""
+
+String expected02 =
+        """import org.junit.runner.RunWith;
+
+import cucumber.api.CucumberOptions;
+import cucumber.api.junit.Cucumber;
+
+@RunWith(Cucumber.class)
+@CucumberOptions(
+        strict = true,
+        features = {"${feature2.absolutePath}"},
+        plugin = {"json:${buildDirectory.absolutePath}/cucumber-parallel/2.json"},
+        monochrome = false,
+        tags = {},
+        glue = {"foo", "bar"})
+public class Group1Parallel02IT {
+}"""
+
+// Depending on the OS, listFiles can list files in different order.  The actual order of files isn't necessary
+
+Assert.assertThat(suite01.text, equalToIgnoringWhiteSpace(expected01))
+Assert.assertThat(suite02.text, equalToIgnoringWhiteSpace(expected02))
+
+

--- a/src/main/java/com/github/timm/cucumber/ModuloCounter.java
+++ b/src/main/java/com/github/timm/cucumber/ModuloCounter.java
@@ -1,0 +1,36 @@
+package com.github.timm.cucumber;
+
+import com.github.timm.cucumber.generate.name.Counter;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * This class counts modulo n, where n is an integer extracted from the configured naming pattern
+ * using regex "{c:(\d*)}".
+ */
+public class ModuloCounter implements Counter {
+
+    private final int module;
+    private int counter = 0;
+
+    /**
+     * Generates a counter from the pattern string.
+     * The pattern string is used to infer the module to count over.
+     * @param patternString the configure naming pattern string
+     */
+    public ModuloCounter(String patternString) {
+        this.module = getModulo(patternString);
+    }
+
+    public int next() {
+        return this.counter++ % this.module;
+    }
+
+    private int getModulo(String extractFrom) {
+        Matcher matcher = Pattern.compile(".*\\{c:(\\d*)}.*").matcher(extractFrom);
+        return matcher.matches()
+            ? Integer.decode(matcher.group(1))
+            : 1;
+    }
+}

--- a/src/main/java/com/github/timm/cucumber/generate/name/PatternNamingScheme.java
+++ b/src/main/java/com/github/timm/cucumber/generate/name/PatternNamingScheme.java
@@ -1,5 +1,7 @@
 package com.github.timm.cucumber.generate.name;
 
+import com.github.timm.cucumber.ModuloCounter;
+
 /**
  * Generate a Class Name based on a pattern.
  *
@@ -13,12 +15,14 @@ package com.github.timm.cucumber.generate.name;
  * <ul>
  * <li>'{f}' - The feature file, converted using supplied naming scheem.</li>
  * <li>'{c}' - A one-up number, formatted to have minimum 2 character width.</li>
+ * <li>'{c:n}' - A one-up number modulo n, with no minimum character width.</li>
  * </ul>
  */
 public class PatternNamingScheme implements ClassNamingScheme {
 
     private final String pattern;
     private final Counter counter;
+    private final Counter moduloCounter;
     private final ClassNamingScheme featureFileNamingScheme;
 
     /**
@@ -31,6 +35,7 @@ public class PatternNamingScheme implements ClassNamingScheme {
 
         this.pattern = pattern;
         this.counter = counter;
+        this.moduloCounter = new ModuloCounter(pattern);
         this.featureFileNamingScheme = featureFileNamingScheme;
     }
 
@@ -43,6 +48,7 @@ public class PatternNamingScheme implements ClassNamingScheme {
         String className =
                         pattern.replace("{f}", featureFileNamingScheme.generate(featureFileName));
         className = className.replace("{c}", String.format("%02d", counter.next()));
+        className = className.replaceAll("\\{c:\\d*}", String.format("%d", moduloCounter.next()));
         return className;
     }
 

--- a/src/test/java/com/github/timm/cucumber/ModuloCounterTest.java
+++ b/src/test/java/com/github/timm/cucumber/ModuloCounterTest.java
@@ -1,0 +1,74 @@
+package com.github.timm.cucumber;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
+import org.junit.Test;
+
+public class ModuloCounterTest {
+
+    private ModuloCounter counter;
+
+    @Test
+    public void shouldCountMod1() {
+        this.counter = new ModuloCounter("NoModule");
+
+        assertThat(this.counter.next(), is(0));
+        assertThat(this.counter.next(), is(0));
+    }
+
+    @Test
+    public void shouldCountMod7() {
+        this.counter = new ModuloCounter("{c:7}");
+
+        assertThat(this.counter.next(), is(0));
+        assertThat(this.counter.next(), is(1));
+        assertThat(this.counter.next(), is(2));
+        assertThat(this.counter.next(), is(3));
+        assertThat(this.counter.next(), is(4));
+        assertThat(this.counter.next(), is(5));
+        assertThat(this.counter.next(), is(6));
+        assertThat(this.counter.next(), is(0));
+        assertThat(this.counter.next(), is(1));
+        assertThat(this.counter.next(), is(2));
+        assertThat(this.counter.next(), is(3));
+        assertThat(this.counter.next(), is(4));
+    }
+
+    @Test
+    public void shouldCountMod6() {
+        this.counter = new ModuloCounter("Group{c:6}-Parallel{c}IT");
+
+        assertThat(this.counter.next(), is(0));
+        assertThat(this.counter.next(), is(1));
+        assertThat(this.counter.next(), is(2));
+        assertThat(this.counter.next(), is(3));
+        assertThat(this.counter.next(), is(4));
+        assertThat(this.counter.next(), is(5));
+        assertThat(this.counter.next(), is(0));
+        assertThat(this.counter.next(), is(1));
+        assertThat(this.counter.next(), is(2));
+        assertThat(this.counter.next(), is(3));
+        assertThat(this.counter.next(), is(4));
+        assertThat(this.counter.next(), is(5));
+    }
+
+    @Test
+    public void shouldCountMod4() {
+        this.counter = new ModuloCounter("fhqwgads-{f}Parallel{c}ITGroup{c:4}");
+
+        assertThat(this.counter.next(), is(0));
+        assertThat(this.counter.next(), is(1));
+        assertThat(this.counter.next(), is(2));
+        assertThat(this.counter.next(), is(3));
+        assertThat(this.counter.next(), is(0));
+        assertThat(this.counter.next(), is(1));
+        assertThat(this.counter.next(), is(2));
+        assertThat(this.counter.next(), is(3));
+        assertThat(this.counter.next(), is(0));
+        assertThat(this.counter.next(), is(1));
+        assertThat(this.counter.next(), is(2));
+        assertThat(this.counter.next(), is(3));
+    }
+
+}

--- a/src/test/java/com/github/timm/cucumber/generate/name/PatternNamingSchemeTest.java
+++ b/src/test/java/com/github/timm/cucumber/generate/name/PatternNamingSchemeTest.java
@@ -37,6 +37,7 @@ public class PatternNamingSchemeTest {
             {"{f}", "FeatureFile"},
             {"{c}", "01"},
             {"{f}{c}", "FeatureFile01"},
+            {"{f}{c}Group{c:1}", "FeatureFile01Group0"},
             {"Foo", "Foo"},
 
             // No validation is performed


### PR DESCRIPTION
This enhancements addresses: https://github.com/temyers/cucumber-jvm-parallel-plugin/issues/135

It allows cucumber tests to be configured for parallel execution at the continuous integration pipeline level by enabling a user to add a modulo counter to the name of each test.

An additional ModuloCounter is created which counts modulo n where n is an integer extracted from the configured naming pattern using regex "{c:(\d*)}"

This ModuloCounter is used in the same way as the oneUpCounter, however, because the ModuloCounter is configured by the naming pattern, it could not be passed in as a constructor argument to the ClassNamingSchemeFactory, instead it is created in the constructor of the PatternNamingScheme.