### PR TITLE
Clean up listfiles order workaround in its

### DIFF
--- a/src/it/junit/custom-output-directory/verify.groovy
+++ b/src/it/junit/custom-output-directory/verify.groovy
@@ -47,13 +47,6 @@ import cucumber.api.junit.Cucumber;
 public class Parallel02IT {
 }"""
 
-// The order of the files isn't important but listFiles may list files in any order
-// This ensures we assert correctly despite file ordering
-if (suite01.text.contains("feature1")) {
-    Assert.assertThat(suite01.text, equalToIgnoringWhiteSpace(expected01))
-    Assert.assertThat(suite02.text, equalToIgnoringWhiteSpace(expected02))
-} else {
-    Assert.assertThat(suite02.text, equalToIgnoringWhiteSpace(expected01))
-    Assert.assertThat(suite01.text, equalToIgnoringWhiteSpace(expected02))
-}
+Assert.assertThat(suite01.text, equalToIgnoringWhiteSpace(expected01))
+Assert.assertThat(suite02.text, equalToIgnoringWhiteSpace(expected02))
 

--- a/src/it/junit/custom-package/verify.groovy
+++ b/src/it/junit/custom-package/verify.groovy
@@ -51,13 +51,6 @@ import cucumber.api.junit.Cucumber;
 public class Parallel02IT {
 }"""
 
-// Depending on the OS, listFiles can list files in different order.  The actual order of files isn't necessary
-
-if (suite01.text.contains("feature1")) {
-    Assert.assertThat(suite01.text, equalToIgnoringWhiteSpace(expected01))
-    Assert.assertThat(suite02.text, equalToIgnoringWhiteSpace(expected02))
-} else {
-    Assert.assertThat(suite02.text, equalToIgnoringWhiteSpace(expected01))
-    Assert.assertThat(suite01.text, equalToIgnoringWhiteSpace(expected02))
-}
+Assert.assertThat(suite01.text, equalToIgnoringWhiteSpace(expected01))
+Assert.assertThat(suite02.text, equalToIgnoringWhiteSpace(expected02))
 

--- a/src/it/junit/custom-template/verify.groovy
+++ b/src/it/junit/custom-template/verify.groovy
@@ -12,13 +12,6 @@ assert suite02.isFile()
 String expected01 = "// This is a custom template for Parallel01IT"
 String expected02 = "// This is a custom template for Parallel02IT"
 
-// The order of the files isn't important but listFiles may list files in any order
-// This ensures we assert correctly despite file ordering
-if (suite01.text.contains("01")) {
-    Assert.assertThat(suite01.text, equalToIgnoringWhiteSpace(expected01))
-    Assert.assertThat(suite02.text, equalToIgnoringWhiteSpace(expected02))
-} else {
-    Assert.assertThat(suite02.text, equalToIgnoringWhiteSpace(expected01))
-    Assert.assertThat(suite01.text, equalToIgnoringWhiteSpace(expected02))
-}
+Assert.assertThat(suite01.text, equalToIgnoringWhiteSpace(expected01))
+Assert.assertThat(suite02.text, equalToIgnoringWhiteSpace(expected02))
 

--- a/src/it/junit/extents-report/verify.groovy
+++ b/src/it/junit/extents-report/verify.groovy
@@ -83,13 +83,6 @@ public class Parallel02IT {
     }
 }"""
 
-// Depending on the OS, listFiles can list files in different order.  The actual order of files isn't necessary
-
-if (suite01.text.contains("feature1")) {
-    Assert.assertThat(suite01.text, equalToIgnoringWhiteSpace(expected01))
-    Assert.assertThat(suite02.text, equalToIgnoringWhiteSpace(expected02))
-} else {
-    Assert.assertThat(suite02.text, equalToIgnoringWhiteSpace(expected01))
-    Assert.assertThat(suite01.text, equalToIgnoringWhiteSpace(expected02))
-}
+Assert.assertThat(suite01.text, equalToIgnoringWhiteSpace(expected01))
+Assert.assertThat(suite02.text, equalToIgnoringWhiteSpace(expected02))
 

--- a/src/it/junit/filter-by-tag3-or/verify.groovy
+++ b/src/it/junit/filter-by-tag3-or/verify.groovy
@@ -11,9 +11,5 @@ assert !suite03.isFile()
 String expected01 = "feature1.feature"
 String expected02 = "feature2.feature"
 
-if (suite01.text.contains(expected01)) {
-    Assert.assertTrue(suite02.text.contains(expected02))
-} else {
-    Assert.assertTrue(suite02.text.contains(expected01))
-    Assert.assertTrue(suite01.text.contains(expected02))
-}
+Assert.assertTrue(suite01.text.contains(expected01))
+Assert.assertTrue(suite02.text.contains(expected02))

--- a/src/it/junit/filter-by-tag6-override-tags-if-tags-in-cucumber-opts/verify.groovy
+++ b/src/it/junit/filter-by-tag6-override-tags-if-tags-in-cucumber-opts/verify.groovy
@@ -52,12 +52,6 @@ import cucumber.api.junit.Cucumber;
 public class Parallel02IT {
 }"""
 
-// Depending on the OS, listFiles can list files in different order.  The actual order of files isn't necessary
 
-if (suite01.text.contains("feature1")) {
-    Assert.assertThat(suite01.text, equalToIgnoringWhiteSpace(expected01))
-    Assert.assertThat(suite02.text, equalToIgnoringWhiteSpace(expected02))
-} else {
-    Assert.assertThat(suite02.text, equalToIgnoringWhiteSpace(expected01))
-    Assert.assertThat(suite01.text, equalToIgnoringWhiteSpace(expected02))
-}
+Assert.assertThat(suite01.text, equalToIgnoringWhiteSpace(expected01))
+Assert.assertThat(suite02.text, equalToIgnoringWhiteSpace(expected02))

--- a/src/it/junit/issue_112-tags-in-vm-scenario-mode/verify.groovy
+++ b/src/it/junit/issue_112-tags-in-vm-scenario-mode/verify.groovy
@@ -38,14 +38,6 @@ The scenario definition tags are:
 */
 """
 
-// The order of the files isn't important but listFiles may list files in any order
-// This ensures we assert correctly despite file ordering
-if (suite01.text.contains("@scenarioTag1")) {
-    Assert.assertThat(suite01.text, equalToIgnoringWhiteSpace(expected01))
-    Assert.assertThat(suite02.text, equalToIgnoringWhiteSpace(expected02))
-} else {
-    Assert.assertThat(suite02.text, equalToIgnoringWhiteSpace(expected01))
-    Assert.assertThat(suite01.text, equalToIgnoringWhiteSpace(expected02))
-    
-}
+Assert.assertThat(suite01.text, equalToIgnoringWhiteSpace(expected01))
+Assert.assertThat(suite02.text, equalToIgnoringWhiteSpace(expected02))
 

--- a/src/it/junit/issue_15-feature-naming-scheme/verify.groovy
+++ b/src/it/junit/issue_15-feature-naming-scheme/verify.groovy
@@ -47,13 +47,5 @@ import cucumber.api.junit.Cucumber;
 public class Feature202IT {
 }"""
 
-// Depending on the OS, listFiles can list files in different order.  The actual order of files isn't necessary
-
-if (suite01.text.contains("feature1")) {
-    Assert.assertThat(suite01.text, equalToIgnoringWhiteSpace(expected01))
-    Assert.assertThat(suite02.text, equalToIgnoringWhiteSpace(expected02))
-} else {
-    Assert.assertThat(suite02.text, equalToIgnoringWhiteSpace(expected01))
-    Assert.assertThat(suite01.text, equalToIgnoringWhiteSpace(expected02))
-}
-
+Assert.assertThat(suite01.text, equalToIgnoringWhiteSpace(expected01))
+Assert.assertThat(suite02.text, equalToIgnoringWhiteSpace(expected02))

--- a/src/it/junit/issue_19-complex-naming-scheme/verify.groovy
+++ b/src/it/junit/issue_19-complex-naming-scheme/verify.groovy
@@ -47,13 +47,5 @@ import cucumber.api.junit.Cucumber;
 public class FooFeature202IT {
 }"""
 
-// Depending on the OS, listFiles can list files in different order.  The actual order of files isn't necessary
-
-if (suite01.text.contains("feature1")) {
-    Assert.assertThat(suite01.text, equalToIgnoringWhiteSpace(expected01))
-    Assert.assertThat(suite02.text, equalToIgnoringWhiteSpace(expected02))
-} else {
-    Assert.assertThat(suite02.text, equalToIgnoringWhiteSpace(expected01))
-    Assert.assertThat(suite01.text, equalToIgnoringWhiteSpace(expected02))
-}
-
+Assert.assertThat(suite01.text, equalToIgnoringWhiteSpace(expected01))
+Assert.assertThat(suite02.text, equalToIgnoringWhiteSpace(expected02))

--- a/src/it/junit/issue_50-no-tags/verify.groovy
+++ b/src/it/junit/issue_50-no-tags/verify.groovy
@@ -14,12 +14,6 @@ String expected02 = "feature2.feature"
 
 Assert.assertTrue(suite01.text.contains(noTags))
 Assert.assertTrue(suite02.text.contains(noTags))
-if (suite01.text.contains(expected01)) {
-    Assert.assertTrue(suite02.text.contains(expected02))
-} else {
-    Assert.assertTrue(suite01.text.contains(expected02))
-    Assert.assertTrue(suite02.text.contains(expected01))
-}
-	
 
-
+Assert.assertTrue(suite01.text.contains(expected01))
+Assert.assertTrue(suite02.text.contains(expected02))

--- a/src/it/junit/issue_76-InconsistentFilters/verify.groovy
+++ b/src/it/junit/issue_76-InconsistentFilters/verify.groovy
@@ -45,13 +45,5 @@ import cucumber.api.junit.Cucumber;
 public class Parallel02IT {
 }"""
 
-// Depending on the OS, listFiles can list files in different order.  The actual order of files isn't necessary
-
-if (suite01.text.contains("feature1")) {
-    Assert.assertThat(suite01.text, equalToIgnoringWhiteSpace(expected01))
-    Assert.assertThat(suite02.text, equalToIgnoringWhiteSpace(expected02))
-} else {
-    Assert.assertThat(suite02.text, equalToIgnoringWhiteSpace(expected01))
-    Assert.assertThat(suite01.text, equalToIgnoringWhiteSpace(expected02))
-}
-
+Assert.assertThat(suite01.text, equalToIgnoringWhiteSpace(expected01))
+Assert.assertThat(suite02.text, equalToIgnoringWhiteSpace(expected02))

--- a/src/it/junit/modular-naming-pattern/verify.groovy
+++ b/src/it/junit/modular-naming-pattern/verify.groovy
@@ -56,9 +56,5 @@ import cucumber.api.junit.Cucumber;
 public class Group1Parallel02IT {
 }"""
 
-// Depending on the OS, listFiles can list files in different order.  The actual order of files isn't necessary
-
 Assert.assertThat(suite01.text, equalToIgnoringWhiteSpace(expected01))
 Assert.assertThat(suite02.text, equalToIgnoringWhiteSpace(expected02))
-
-

--- a/src/it/junit/multiple-format/verify.groovy
+++ b/src/it/junit/multiple-format/verify.groovy
@@ -47,13 +47,5 @@ import cucumber.api.junit.Cucumber;
 public class Parallel02IT {
 }"""
 
-// Depending on the OS, listFiles can list files in different order.  The actual order of files isn't necessary
-
-if (suite01.text.contains("feature1")) {
-    Assert.assertThat(suite01.text, equalToIgnoringWhiteSpace(expected01))
-    Assert.assertThat(suite02.text, equalToIgnoringWhiteSpace(expected02))
-} else {
-    Assert.assertThat(suite02.text, equalToIgnoringWhiteSpace(expected01))
-    Assert.assertThat(suite01.text, equalToIgnoringWhiteSpace(expected02))
-}
-
+Assert.assertThat(suite01.text, equalToIgnoringWhiteSpace(expected01))
+Assert.assertThat(suite02.text, equalToIgnoringWhiteSpace(expected02))

--- a/src/it/junit/simple-it/verify.groovy
+++ b/src/it/junit/simple-it/verify.groovy
@@ -47,13 +47,6 @@ import cucumber.api.junit.Cucumber;
 public class Parallel02IT {
 }"""
 
-// Depending on the OS, listFiles can list files in different order.  The actual order of files isn't necessary
 
-if (suite01.text.contains("feature1")) {
-    Assert.assertThat(suite01.text, equalToIgnoringWhiteSpace(expected01))
-    Assert.assertThat(suite02.text, equalToIgnoringWhiteSpace(expected02))
-} else {
-    Assert.assertThat(suite02.text, equalToIgnoringWhiteSpace(expected01))
-    Assert.assertThat(suite01.text, equalToIgnoringWhiteSpace(expected02))
-}
-
+Assert.assertThat(suite01.text, equalToIgnoringWhiteSpace(expected01))
+Assert.assertThat(suite02.text, equalToIgnoringWhiteSpace(expected02))

--- a/src/it/testng/filter-by-tag6-override-tags-if-tags-in-cucumber-opts/verify.groovy
+++ b/src/it/testng/filter-by-tag6-override-tags-if-tags-in-cucumber-opts/verify.groovy
@@ -46,12 +46,5 @@ import cucumber.api.testng.AbstractTestNGCucumberTests;
 public class Parallel02IT extends AbstractTestNGCucumberTests {
 }"""
 
-// Depending on the OS, listFiles can list files in different order.  The actual order of files isn't necessary
-
-if (suite01.text.contains("feature1")) {
-    Assert.assertThat(suite01.text, equalToIgnoringWhiteSpace(expected01))
-    Assert.assertThat(suite02.text, equalToIgnoringWhiteSpace(expected02))
-} else {
-    Assert.assertThat(suite02.text, equalToIgnoringWhiteSpace(expected01))
-    Assert.assertThat(suite01.text, equalToIgnoringWhiteSpace(expected02))
-}
+Assert.assertThat(suite01.text, equalToIgnoringWhiteSpace(expected01))
+Assert.assertThat(suite02.text, equalToIgnoringWhiteSpace(expected02))

--- a/src/it/testng/issue_15-feature-naming-scheme/verify.groovy
+++ b/src/it/testng/issue_15-feature-naming-scheme/verify.groovy
@@ -39,13 +39,7 @@ import cucumber.api.testng.AbstractTestNGCucumberTests;
 public class Feature202IT extends AbstractTestNGCucumberTests {
 }"""
 
-// Depending on the OS, listFiles can list files in different order.  The actual order of files isn't necessary
 
-if (suite01.text.contains("feature1")) {
-    Assert.assertThat(suite01.text, equalToIgnoringWhiteSpace(expected01))
-    Assert.assertThat(suite02.text, equalToIgnoringWhiteSpace(expected02))
-} else {
-    Assert.assertThat(suite02.text, equalToIgnoringWhiteSpace(expected01))
-    Assert.assertThat(suite01.text, equalToIgnoringWhiteSpace(expected02))
-}
+Assert.assertThat(suite01.text, equalToIgnoringWhiteSpace(expected01))
+Assert.assertThat(suite02.text, equalToIgnoringWhiteSpace(expected02))
 

--- a/src/it/testng/issue_50-no-tags/verify.groovy
+++ b/src/it/testng/issue_50-no-tags/verify.groovy
@@ -14,12 +14,6 @@ String expected02 = "feature2.feature"
 
 Assert.assertTrue(suite01.text.contains(noTags))
 Assert.assertTrue(suite02.text.contains(noTags))
-if (suite01.text.contains(expected01)) {
-    Assert.assertTrue(suite02.text.contains(expected02))
-} else {
-    Assert.assertTrue(suite01.text.contains(expected02))
-    Assert.assertTrue(suite02.text.contains(expected01))
-}
-	
 
-
+Assert.assertTrue(suite01.text.contains(expected01))
+Assert.assertTrue(suite02.text.contains(expected02))

--- a/src/it/testng/issue_76-InconsistentFilters/verify.groovy
+++ b/src/it/testng/issue_76-InconsistentFilters/verify.groovy
@@ -38,14 +38,5 @@ import cucumber.api.testng.AbstractTestNGCucumberTests;
         glue = {"foo", "bar"})
 public class Parallel02IT extends AbstractTestNGCucumberTests {
 }"""
-
-// Depending on the OS, listFiles can list files in different order.  The actual order of files isn't necessary
-
-if (suite01.text.contains("feature1")) {
-    Assert.assertThat(suite01.text, equalToIgnoringWhiteSpace(expected01))
-    Assert.assertThat(suite02.text, equalToIgnoringWhiteSpace(expected02))
-} else {
-    Assert.assertThat(suite02.text, equalToIgnoringWhiteSpace(expected01))
-    Assert.assertThat(suite01.text, equalToIgnoringWhiteSpace(expected02))
-}
-
+Assert.assertThat(suite01.text, equalToIgnoringWhiteSpace(expected01))
+Assert.assertThat(suite02.text, equalToIgnoringWhiteSpace(expected02))

--- a/src/it/testng/multiple-format/verify.groovy
+++ b/src/it/testng/multiple-format/verify.groovy
@@ -41,13 +41,5 @@ import cucumber.api.testng.AbstractTestNGCucumberTests;
 public class Parallel02IT extends AbstractTestNGCucumberTests {
 }"""
 
-// Depending on the OS, listFiles can list files in different order.  The actual order of files isn't necessary
-
-if (suite01.text.contains("feature1")) {
-    Assert.assertThat(suite01.text, equalToIgnoringWhiteSpace(expected01))
-    Assert.assertThat(suite02.text, equalToIgnoringWhiteSpace(expected02))
-} else {
-    Assert.assertThat(suite02.text, equalToIgnoringWhiteSpace(expected01))
-    Assert.assertThat(suite01.text, equalToIgnoringWhiteSpace(expected02))
-}
-
+Assert.assertThat(suite01.text, equalToIgnoringWhiteSpace(expected01))
+Assert.assertThat(suite02.text, equalToIgnoringWhiteSpace(expected02))

--- a/src/it/testng/output-directory/verify.groovy
+++ b/src/it/testng/output-directory/verify.groovy
@@ -41,13 +41,5 @@ import cucumber.api.testng.AbstractTestNGCucumberTests;
 public class Parallel02IT extends AbstractTestNGCucumberTests {
 }"""
 
-// Depending on the OS, listFiles can list files in different order.  The actual order of files isn't necessary
-
-if (suite01.text.contains("feature1")) {
-    Assert.assertThat(suite01.text, equalToIgnoringWhiteSpace(expected01))
-    Assert.assertThat(suite02.text, equalToIgnoringWhiteSpace(expected02))
-} else {
-    Assert.assertThat(suite02.text, equalToIgnoringWhiteSpace(expected01))
-    Assert.assertThat(suite01.text, equalToIgnoringWhiteSpace(expected02))
-}
-
+Assert.assertThat(suite01.text, equalToIgnoringWhiteSpace(expected01))
+Assert.assertThat(suite02.text, equalToIgnoringWhiteSpace(expected02))

--- a/src/it/testng/simple-it/verify.groovy
+++ b/src/it/testng/simple-it/verify.groovy
@@ -41,13 +41,5 @@ import cucumber.api.testng.AbstractTestNGCucumberTests;
 public class Parallel02IT extends AbstractTestNGCucumberTests {
 }"""
 
-// Depending on the OS, listFiles can list files in different order.  The actual order of files isn't necessary
-
-if (suite01.text.contains("feature1")) {
-    Assert.assertThat(suite01.text, equalToIgnoringWhiteSpace(expected01))
-    Assert.assertThat(suite02.text, equalToIgnoringWhiteSpace(expected02))
-} else {
-    Assert.assertThat(suite02.text, equalToIgnoringWhiteSpace(expected01))
-    Assert.assertThat(suite01.text, equalToIgnoringWhiteSpace(expected02))
-}
-
+Assert.assertThat(suite01.text, equalToIgnoringWhiteSpace(expected01))
+Assert.assertThat(suite02.text, equalToIgnoringWhiteSpace(expected02))


### PR DESCRIPTION
Depending on OS `FileUtils.listFiles` would return files in different
 order. Sorting these in 91fa62ff624b15b2d812fb18f43332595edab0e5 stopped this behaviour. As such we can
 clean up the integration tests a bit.