### PR TITLE
Added failing test for issue 150

### DIFF
--- a/src/it/junit/issue_150-language-tag/pom.xml
+++ b/src/it/junit/issue_150-language-tag/pom.xml
@@ -1,0 +1,55 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>com.github.temyers.it</groupId>
+    <artifactId>simple-it</artifactId>
+    <version>1.0-SNAPSHOT</version>
+
+    <description>A simple IT verifying the basic use case.</description>
+
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <cucumber.version>1.2.2</cucumber.version>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>info.cukes</groupId>
+            <artifactId>cucumber-junit</artifactId>
+            <version>${cucumber.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>info.cukes</groupId>
+            <artifactId>cucumber-java</artifactId>
+            <version>${cucumber.version}</version>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>@project.groupId@</groupId>
+                <artifactId>@project.artifactId@</artifactId>
+                <version>@project.version@</version>
+                <executions>
+                    <execution>
+                        <id>generateRunners</id>
+                        <phase>generate-test-sources</phase>
+                        <goals>
+                            <goal>generateRunners</goal>
+                        </goals>
+                        <configuration>
+                            <glue>
+                                <package>foo</package>
+                                <package>bar</package>
+                            </glue>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/src/it/junit/issue_150-language-tag/pom.xml
+++ b/src/it/junit/issue_150-language-tag/pom.xml
@@ -5,10 +5,10 @@
     <modelVersion>4.0.0</modelVersion>
 
     <groupId>com.github.temyers.it</groupId>
-    <artifactId>simple-it</artifactId>
+    <artifactId>issue_150-language-tag</artifactId>
     <version>1.0-SNAPSHOT</version>
 
-    <description>A simple IT verifying the basic use case.</description>
+    <description>Plugin not working with cucumber #language-tag</description>
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/src/it/junit/issue_150-language-tag/src/test/resources/features/feature1.feature
+++ b/src/it/junit/issue_150-language-tag/src/test/resources/features/feature1.feature
@@ -1,0 +1,21 @@
+#language:de
+Funktionalität: Feature1
+
+  Szenario: Generate Junit Runner for each feature file
+    Gegeben sei I have feature files
+    Wenn I generate Maven sources
+    Dann the file "target/generated-test-sources/1IT.java" should exist
+    Und it should contain:
+    """
+    @RunWith(Cucumber.class)
+    @CucumberOptions(
+        strict = true,
+        features = {"classpath:features/feature1.feature"},
+        format = {"json:target/cucumber-parallel/1.json",
+    "pretty"},
+        monochrome = false,
+        tags = {"@complete", "@accepted"},
+        glue = {"foo", "bar"})
+    public class Parallel01IT {
+    }
+    """

--- a/src/it/junit/issue_150-language-tag/src/test/resources/features/feature2.feature
+++ b/src/it/junit/issue_150-language-tag/src/test/resources/features/feature2.feature
@@ -1,0 +1,19 @@
+Feature: Feature1
+
+  Scenario: Generate Junit Runner for each feature file
+    Given I have feature files
+    When I generate Maven sources
+    Then the file "target/generated-test-sources/1IT.java" should exist
+    And it should contain:
+    """
+    @RunWith(Cucumber.class)
+    @CucumberOptions(
+        strict = true,
+        features = {"classpath:features/feature2.feature"},
+        format = {"json:target/cucumber-parallel/2.json", "pretty"},
+        monochrome = false,
+        tags = {"@complete", "@accepted"},
+        glue = {"foo", "bar"})
+    public class Parallel02IT {
+    }
+    """

--- a/src/it/junit/issue_150-language-tag/verify.groovy
+++ b/src/it/junit/issue_150-language-tag/verify.groovy
@@ -1,0 +1,52 @@
+import org.junit.Assert
+
+import static org.hamcrest.Matchers.equalToIgnoringWhiteSpace
+
+File buildDirectory = new File(basedir, "target");
+
+File suite01 = new File(basedir, "target/generated-test-sources/cucumber/Parallel01IT.java");
+File suite02 = new File(basedir, "target/generated-test-sources/cucumber/Parallel02IT.java");
+
+File feature1 = new File(basedir, "/src/test/resources/features/feature1.feature");
+File feature2 = new File(basedir, "/src/test/resources/features/feature2.feature");
+
+assert suite01.isFile()
+assert suite02.isFile()
+
+String expected01 =
+        """import org.junit.runner.RunWith;
+
+import cucumber.api.CucumberOptions;
+import cucumber.api.junit.Cucumber;
+
+@RunWith(Cucumber.class)
+@CucumberOptions(
+        strict = true,
+        features = {"${feature1.absolutePath}"},
+        plugin = {"json:${buildDirectory.absolutePath}/cucumber-parallel/1.json"},
+        monochrome = false,
+        tags = {},
+        glue = {"foo", "bar"})
+public class Parallel01IT {
+}"""
+
+String expected02 =
+        """import org.junit.runner.RunWith;
+
+import cucumber.api.CucumberOptions;
+import cucumber.api.junit.Cucumber;
+
+@RunWith(Cucumber.class)
+@CucumberOptions(
+        strict = true,
+        features = {"${feature2.absolutePath}"},
+        plugin = {"json:${buildDirectory.absolutePath}/cucumber-parallel/2.json"},
+        monochrome = false,
+        tags = {},
+        glue = {"foo", "bar"})
+public class Parallel02IT {
+}"""
+
+
+Assert.assertThat(suite01.text, equalToIgnoringWhiteSpace(expected01))
+Assert.assertThat(suite02.text, equalToIgnoringWhiteSpace(expected02))


### PR DESCRIPTION
Its a copy of simple-it, only feature1.feature was changed, so it uses the #language-tag. In this case "de" for german. The Gherkin-Keywords were modified accordingly. It should create 2 runners, but fails parsing the german feature.